### PR TITLE
Harden subminer-scrum-master pre-handoff policy checks

### DIFF
--- a/.agents/skills/subminer-scrum-master/SKILL.md
+++ b/.agents/skills/subminer-scrum-master/SKILL.md
@@ -85,6 +85,18 @@ Preferred flow:
 
 Never hand off nontrivial work without stating what was verified and what was skipped.
 
+## Pre-Handoff Policy Checks (Required)
+
+Before handoff, always ask and answer both of these questions explicitly:
+
+1. **Docs update required?**
+2. **Changelog fragment required?**
+
+Rules:
+- Do not assume silence implies "no." Record an explicit yes/no decision for each item.
+- If the answer is yes, either complete the update or report the blocker before handoff.
+- Include the final answers in the handoff summary even when both answers are "no."
+
 ## Failure / Scope Handling
 
 - If a worker hits ambiguity, pause and ask the user.
@@ -128,4 +140,7 @@ At the end, report:
 - whether backlog was used and what changed
 - which workers were dispatched and what they owned
 - what verification ran
+- explicit answers to:
+  - docs update required?
+  - changelog fragment required?
 - blockers, skips, and risks

--- a/changes/2026-03-13-scrum-master-handoff-checks.md
+++ b/changes/2026-03-13-scrum-master-handoff-checks.md
@@ -1,0 +1,4 @@
+type: internal
+area: workflow
+
+- Hardened the `subminer-scrum-master` skill to explicitly answer whether docs updates and changelog fragments are required before handoff.


### PR DESCRIPTION
### Motivation
- Ensure the repo-local `subminer-scrum-master` skill cannot hand off work without explicitly deciding and reporting whether a docs update or a changelog fragment is required.

### Description
- Added a required `Pre-Handoff Policy Checks (Required)` section to `.agents/skills/subminer-scrum-master/SKILL.md` that mandates asking and answering `Docs update required?` and `Changelog fragment required?` and records rules for yes/no handling.
- Updated the skill's `Output Expectations` to require explicit answers to those two questions in the final handoff summary.
- Added a changelog fragment at `changes/2026-03-13-scrum-master-handoff-checks.md` (`type: internal`, `area: workflow`).

### Testing
- Ran `bun run changelog:lint` (executes `scripts/build-changelog.ts lint`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3c9fae300832a965d6b5d8bff0e4c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced pre-handoff quality checks for scrum master workflows, requiring explicit assessment of whether documentation updates and changelog fragments are needed before completion.

* **Chores**
  * Added changelog entry documenting workflow refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->