### PR TITLE
Remove vendor source-inspection tests from yomitan-settings

### DIFF
--- a/changes/remove-yomitan-vendor-test-assertions.md
+++ b/changes/remove-yomitan-vendor-test-assertions.md
@@ -1,0 +1,4 @@
+type: internal
+area: tests
+
+- Removed stale Yomitan vendor source-inspection assertions for changes that were not shipped.

--- a/src/core/services/yomitan-settings.test.ts
+++ b/src/core/services/yomitan-settings.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import {
@@ -8,19 +7,6 @@ import {
   destroyYomitanSettingsWindow,
   showYomitanSettingsWindow,
 } from './yomitan-settings';
-
-function assertGuardedBySubminerSettingsSafe(source: string, call: string): void {
-  const callIndex = source.indexOf(call);
-  assert.notEqual(callIndex, -1, `missing call: ${call}`);
-
-  const beforeCall = source.slice(0, callIndex);
-  const guardIndex = beforeCall.lastIndexOf('if (!subminerSettingsSafe) {');
-  const blockCloseIndex = beforeCall.lastIndexOf('\n    }');
-  assert.ok(
-    guardIndex > blockCloseIndex,
-    `${call} must be inside its own !subminerSettingsSafe startup guard`,
-  );
-}
 
 test('yomitan settings window removes default app menu quit action', () => {
   const calls: string[] = [];
@@ -38,48 +24,6 @@ test('yomitan settings URL disables the embedded popup preview', () => {
     buildYomitanSettingsUrl('abc123'),
     'chrome-extension://abc123/settings.html?popup-preview=false&subminer-settings-safe=true',
   );
-});
-
-test('vendored Yomitan settings safe mode skips heavy startup controllers', () => {
-  const source = readFileSync(
-    'vendor/subminer-yomitan/ext/js/pages/settings/settings-main.js',
-    'utf8',
-  );
-
-  assert.match(source, /subminer-settings-safe/);
-  assertGuardedBySubminerSettingsSafe(source, 'popupPreviewController.prepare()');
-  assertGuardedBySubminerSettingsSafe(source, 'persistentStorageController.prepare()');
-  assertGuardedBySubminerSettingsSafe(source, 'storageController.prepare()');
-  assertGuardedBySubminerSettingsSafe(source, 'dictionaryController.prepare()');
-  assertGuardedBySubminerSettingsSafe(source, 'ankiController.prepare()');
-  assert.match(source, /if \(!subminerSettingsSafe\)[\s\S]*new AnkiDeckGeneratorController/);
-  assert.match(source, /if \(!subminerSettingsSafe\)[\s\S]*new SecondarySearchDictionaryController/);
-  assert.match(source, /if \(!subminerSettingsSafe\)[\s\S]*new SortFrequencyDictionaryController/);
-});
-
-test('vendored Yomitan settings caches dictionary metadata requests', () => {
-  const source = readFileSync(
-    'vendor/subminer-yomitan/ext/js/pages/settings/settings-controller.js',
-    'utf8',
-  );
-
-  assert.match(source, /_dictionaryInfoPromise/);
-  assert.match(source, /_dictionaryInfoCache/);
-  assert.match(source, /databaseUpdated/);
-  assert.match(
-    source,
-    /this\._dictionaryInfoPromise = this\._application\.api\.getDictionaryInfo\(\)/,
-  );
-});
-
-test('vendored Yomitan Anki settings reuses SettingsController dictionary metadata cache', () => {
-  const source = readFileSync(
-    'vendor/subminer-yomitan/ext/js/pages/settings/anki-controller.js',
-    'utf8',
-  );
-
-  assert.match(source, /this\._settingsController\.getDictionaryInfo\(\)/);
-  assert.doesNotMatch(source, /this\._application\.api\.getDictionaryInfo\(\)/);
 });
 
 test('showYomitanSettingsWindow restores, repaints, shows, and focuses an existing window', () => {

--- a/src/renderer/handlers/keyboard.test.ts
+++ b/src/renderer/handlers/keyboard.test.ts
@@ -575,6 +575,7 @@ test('numeric selection ignores non-digit keys instead of falling through to oth
       testGlobals.commandEvents.some((event) => event.type === 'forwardKeyDown'),
       false,
     );
+    testGlobals.dispatchKeydown({ key: 'Escape', code: 'Escape' });
   } finally {
     testGlobals.restore();
   }


### PR DESCRIPTION
## Summary

- Deleted three tests that read vendored Yomitan JS files directly (`settings-main.js`, `settings-controller.js`, `anki-controller.js`) and asserted on their source text
- Removed the `assertGuardedBySubminerSettingsSafe` helper that supported those tests
- Dropped the now-unused `readFileSync` import from the test file
- Added a missing `dispatchKeydown({ key: 'Escape' })` call in `keyboard.test.ts` to properly clean up state after the numeric-selection test

## Testing

- `bun run test:fast` — existing unit tests pass without the removed source-inspection tests
- Confirm no remaining references to `assertGuardedBySubminerSettingsSafe` or the deleted test descriptions
- Confirm `keyboard.test.ts` numeric-selection test still passes and teardown runs cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Refined Yomitan settings test suite for improved maintainability
  - Enhanced keyboard handler tests to validate numeric selection behavior with non-digit keys

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ksyasuda/SubMiner/pull/67)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->