### PR TITLE
feat(keybindings): add mouse button support for mpv keybindings

### DIFF
--- a/changes/mouse-keybindings.md
+++ b/changes/mouse-keybindings.md
@@ -1,0 +1,4 @@
+type: fixed
+area: config
+
+- Fixed settings keybinding capture and runtime handling for mouse buttons, including side-button bindings like `MBTN_BACK` and `MBTN_FORWARD`.

--- a/docs-site/configuration.md
+++ b/docs-site/configuration.md
@@ -571,13 +571,15 @@ See `config.example.jsonc` for detailed configuration options and more examples.
     { "key": "ArrowRight", "command": ["seek", 5] },
     { "key": "ArrowLeft", "command": ["seek", -5] },
     { "key": "Shift+ArrowRight", "command": ["seek", 30] },
+    { "key": "MBTN_BACK", "command": ["sub-seek", -1] },
+    { "key": "MBTN_FORWARD", "command": ["sub-seek", 1] },
     { "key": "KeyR", "command": ["script-binding", "immersive/auto-replay"] },
     { "key": "KeyA", "command": ["script-message", "ankiconnect-add-note"] }
   ]
 }
 ```
 
-**Key format:** Use `KeyboardEvent.code` values (`Space`, `ArrowRight`, `KeyR`, etc.) with optional modifiers (`Ctrl+`, `Alt+`, `Shift+`, `Meta+`).
+**Key format:** Use `KeyboardEvent.code` values (`Space`, `ArrowRight`, `KeyR`, etc.) with optional modifiers (`Ctrl+`, `Alt+`, `Shift+`, `Meta+`). Mouse buttons use mpv button names: `MBTN_LEFT`, `MBTN_MID`, `MBTN_RIGHT`, `MBTN_BACK`, and `MBTN_FORWARD`.
 
 **Disable a default binding:** Set command to `null`:
 

--- a/docs-site/shortcuts.md
+++ b/docs-site/shortcuts.md
@@ -152,9 +152,13 @@ The `keybindings` array overrides or extends the overlay's built-in key handling
   "keybindings": [
     { "key": "f", "command": ["cycle", "fullscreen"] },
     { "key": "m", "command": ["cycle", "mute"] },
+    { "key": "MBTN_BACK", "command": ["sub-seek", -1] },
+    { "key": "MBTN_FORWARD", "command": ["sub-seek", 1] },
     { "key": "Space", "command": null }, // disable default Space → pause
   ],
 }
 ```
+
+Mouse keybinding names are `MBTN_LEFT`, `MBTN_MID`, `MBTN_RIGHT`, `MBTN_BACK`, and `MBTN_FORWARD`.
 
 Both `shortcuts`, `keybindings`, and `subtitleSidebar` are [hot-reloadable](/configuration#hot-reload-behavior) — changes take effect without restarting SubMiner.

--- a/plugin/subminer/session_bindings.lua
+++ b/plugin/subminer/session_bindings.lua
@@ -24,6 +24,11 @@ local KEY_NAME_MAP = {
 	BracketLeft = "[",
 	BracketRight = "]",
 	Backquote = "`",
+	MBTN_LEFT = "MBTN_LEFT",
+	MBTN_MID = "MBTN_MID",
+	MBTN_RIGHT = "MBTN_RIGHT",
+	MBTN_BACK = "MBTN_BACK",
+	MBTN_FORWARD = "MBTN_FORWARD",
 }
 
 local MODIFIER_MAP = {

--- a/scripts/test-plugin-session-bindings.lua
+++ b/scripts/test-plugin-session-bindings.lua
@@ -231,6 +231,14 @@ local ctx = {
 					},
 					{
 						key = {
+							code = "MBTN_BACK",
+							modifiers = {},
+						},
+						actionType = "mpv-command",
+						command = { "sub-seek", -1 },
+					},
+					{
+						key = {
 							code = "KeyW",
 							modifiers = {},
 						},
@@ -317,6 +325,7 @@ local expected_mpv_bindings = {
 	{ keys = "L", command = { "sub-seek", 1 } },
 	{ keys = "q", command = { "quit" } },
 	{ keys = "Ctrl+w", command = { "quit" } },
+	{ keys = "MBTN_BACK", command = { "sub-seek", -1 } },
 }
 
 for _, expected in ipairs(expected_mpv_bindings) do

--- a/src/core/services/session-bindings.test.ts
+++ b/src/core/services/session-bindings.test.ts
@@ -162,6 +162,46 @@ test('compileSessionBindings resolves CommandOrControl in DOM key strings per pl
   );
 });
 
+test('compileSessionBindings supports mpv mouse button keybindings', () => {
+  const result = compileSessionBindings({
+    shortcuts: createShortcuts(),
+    keybindings: [
+      createKeybinding('MBTN_BACK', ['sub-seek', -1]),
+      createKeybinding('Shift+MBTN_FORWARD', ['sub-seek', 1]),
+    ],
+    platform: 'win32',
+  });
+
+  assert.deepEqual(result.warnings, []);
+  assert.deepEqual(
+    result.bindings.map((binding) => ({
+      code: binding.key.code,
+      modifiers: binding.key.modifiers,
+      command: binding.actionType === 'mpv-command' ? binding.command : null,
+    })),
+    [
+      { code: 'MBTN_BACK', modifiers: [], command: ['sub-seek', -1] },
+      { code: 'MBTN_FORWARD', modifiers: ['shift'], command: ['sub-seek', 1] },
+    ],
+  );
+});
+
+test('compileSessionBindings keeps mouse buttons scoped to keybindings', () => {
+  const result = compileSessionBindings({
+    shortcuts: createShortcuts({
+      openJimaku: 'MBTN_BACK',
+    }),
+    keybindings: [createKeybinding('MBTN_BACK', ['sub-seek', -1])],
+    platform: 'win32',
+  });
+
+  assert.deepEqual(result.bindings.map((binding) => binding.sourcePath), ['keybindings[0].key']);
+  assert.deepEqual(
+    result.warnings.map((warning) => `${warning.kind}:${warning.path}`),
+    ['unsupported:shortcuts.openJimaku'],
+  );
+});
+
 test('compileSessionBindings drops conflicting bindings that canonicalize to the same key', () => {
   const result = compileSessionBindings({
     shortcuts: createShortcuts({

--- a/src/core/services/session-bindings.ts
+++ b/src/core/services/session-bindings.ts
@@ -30,6 +30,13 @@ type DraftBinding = {
 };
 
 const MODIFIER_ORDER: SessionKeyModifier[] = ['ctrl', 'alt', 'shift', 'meta'];
+const MPV_MOUSE_BUTTON_CODES = new Set([
+  'MBTN_LEFT',
+  'MBTN_MID',
+  'MBTN_RIGHT',
+  'MBTN_BACK',
+  'MBTN_FORWARD',
+]);
 
 const SESSION_SHORTCUT_ACTIONS: Array<{
   key: keyof Omit<ConfiguredShortcuts, 'multiCopyTimeoutMs'>;
@@ -64,9 +71,18 @@ function isValidCommandEntry(value: unknown): value is string | number {
   return typeof value === 'string' || typeof value === 'number';
 }
 
-function normalizeCodeToken(token: string): string | null {
+function normalizeCodeToken(
+  token: string,
+  options: { allowMouseButtons?: boolean } = {},
+): string | null {
   const normalized = token.trim();
   if (!normalized) return null;
+  if (options.allowMouseButtons === true) {
+    const normalizedMouse = normalized.toUpperCase();
+    if (MPV_MOUSE_BUTTON_CODES.has(normalizedMouse)) {
+      return normalizedMouse;
+    }
+  }
   if (/^[a-z]$/i.test(normalized)) {
     return `Key${normalized.toUpperCase()}`;
   }
@@ -238,7 +254,7 @@ function parseDomKeyString(
     };
   }
 
-  const code = normalizeCodeToken(keyToken);
+  const code = normalizeCodeToken(keyToken, { allowMouseButtons: true });
   if (!code) {
     return {
       key: null,

--- a/src/renderer/handlers/keyboard.test.ts
+++ b/src/renderer/handlers/keyboard.test.ts
@@ -322,17 +322,30 @@ function installKeyboardTestGlobals() {
     }
   }
 
-  function dispatchDocumentMouseDown(event: { button: number; target?: unknown }): void {
+  function dispatchMousedown(event: {
+    button: number;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    altKey?: boolean;
+    shiftKey?: boolean;
+    target?: unknown;
+  }): void {
     const listeners = documentListeners.get('mousedown') ?? [];
     const mouseEvent = {
       button: event.button,
-      target: event.target ?? null,
+      ctrlKey: event.ctrlKey ?? false,
+      metaKey: event.metaKey ?? false,
+      altKey: event.altKey ?? false,
+      shiftKey: event.shiftKey ?? false,
       preventDefault: () => {},
+      target: event.target ?? null,
     };
     for (const listener of listeners) {
       listener(mouseEvent);
     }
   }
+
+  const dispatchDocumentMouseDown = dispatchMousedown;
 
   function dispatchFocusInOnPopup(): void {
     const listeners = documentListeners.get('focusin') ?? [];
@@ -389,6 +402,7 @@ function installKeyboardTestGlobals() {
     windowFocusCalls: () => windowFocusCalls,
     dispatchKeydown,
     dispatchDocumentMouseDown,
+    dispatchMousedown,
     dispatchFocusInOnPopup,
     dispatchWindowEvent,
     setPopupVisible: (value: boolean) => {
@@ -1031,6 +1045,31 @@ test('paused configured subtitle-jump keybinding re-applies pause after backward
       ['sub-seek', -1],
       ['set_property', 'pause', 'yes'],
     ]);
+  } finally {
+    testGlobals.restore();
+  }
+});
+
+test('configured mouse button keybinding dispatches through overlay mouse handling', async () => {
+  const { handlers, testGlobals } = createKeyboardHandlerHarness();
+
+  try {
+    await handlers.setupMpvInputForwarding();
+    handlers.updateSessionBindings([
+      {
+        sourcePath: 'keybindings[0].key',
+        originalKey: 'MBTN_BACK',
+        key: { code: 'MBTN_BACK', modifiers: [] },
+        actionType: 'mpv-command',
+        command: ['sub-seek', -1],
+      },
+    ] as never);
+    testGlobals.setPlaybackPausedResponse(false);
+
+    testGlobals.dispatchMousedown({ button: 3 });
+    await wait(0);
+
+    assert.deepEqual(testGlobals.mpvCommands.slice(-1), [['sub-seek', -1]]);
   } finally {
     testGlobals.restore();
   }

--- a/src/renderer/handlers/keyboard.ts
+++ b/src/renderer/handlers/keyboard.ts
@@ -37,6 +37,13 @@ export function createKeyboardHandlers(
   const CHORD_TIMEOUT_MS = 1000;
   const MPV_INPUT_FORWARDING_CONFIG_LOAD_TIMEOUT_MS = 50;
   const KEYBOARD_SELECTED_WORD_CLASS = 'keyboard-selected';
+  const MOUSE_BUTTON_CODE_BY_BUTTON: Record<number, string> = {
+    0: 'MBTN_LEFT',
+    1: 'MBTN_MID',
+    2: 'MBTN_RIGHT',
+    3: 'MBTN_BACK',
+    4: 'MBTN_FORWARD',
+  };
   let pendingSelectionAnchorAfterSubtitleSeek: 'start' | 'end' | null = null;
   let pendingLookupRefreshAfterSubtitleSeek = false;
   let resetSelectionToStartOnNextSubtitleSync = false;
@@ -78,6 +85,19 @@ export function createKeyboardHandlers(
     if (e.shiftKey) parts.push('Shift');
     if (e.metaKey) parts.push('Meta');
     parts.push(e.code);
+    return parts.join('+');
+  }
+
+  function mouseEventToString(e: MouseEvent): string | null {
+    const code = MOUSE_BUTTON_CODE_BY_BUTTON[e.button];
+    if (!code) return null;
+
+    const parts: string[] = [];
+    if (e.ctrlKey) parts.push('Ctrl');
+    if (e.altKey) parts.push('Alt');
+    if (e.shiftKey) parts.push('Shift');
+    if (e.metaKey) parts.push('Meta');
+    parts.push(code);
     return parts.join('+');
   }
 
@@ -1216,6 +1236,14 @@ export function createKeyboardHandlers(
     });
 
     document.addEventListener('mousedown', (e: MouseEvent) => {
+      const mouseString = mouseEventToString(e);
+      const binding = mouseString ? ctx.state.sessionBindingMap.get(mouseString) : undefined;
+      if (binding) {
+        e.preventDefault();
+        dispatchSessionBinding(binding);
+        return;
+      }
+
       if (e.button === 2 && !isInteractiveTarget(e.target)) {
         e.preventDefault();
         void window.electronAPI

--- a/src/renderer/modals/session-help-sections.ts
+++ b/src/renderer/modals/session-help-sections.ts
@@ -57,6 +57,11 @@ const KEY_NAME_MAP: Record<string, string> = {
   Super: 'Meta',
   Meta: 'Meta',
   Backspace: 'Backspace',
+  MBTN_LEFT: 'Mouse Left',
+  MBTN_MID: 'Mouse Middle',
+  MBTN_RIGHT: 'Mouse Right',
+  MBTN_BACK: 'Mouse Back',
+  MBTN_FORWARD: 'Mouse Forward',
 };
 
 function normalizeKeyToken(token: string): string {

--- a/src/settings/key-input.test.ts
+++ b/src/settings/key-input.test.ts
@@ -5,6 +5,7 @@ import {
   buildMpvKeybindingConfigValue,
   createMpvKeybindingRows,
   keyboardEventToConfigKey,
+  mouseEventToConfigKey,
 } from './key-input';
 
 test('keyboardEventToConfigKey formats Electron accelerators from learned input', () => {
@@ -72,6 +73,23 @@ test('keyboardEventToConfigKey formats mpv key bindings from learned input', () 
       'mpv-key',
     ),
     'Ctrl+Shift+K',
+  );
+});
+
+test('mouseEventToConfigKey formats mpv mouse buttons from learned input', () => {
+  assert.equal(
+    mouseEventToConfigKey(
+      { button: 3, ctrlKey: false, altKey: false, shiftKey: false, metaKey: false },
+      'dom-code',
+    ),
+    'MBTN_BACK',
+  );
+  assert.equal(
+    mouseEventToConfigKey(
+      { button: 4, ctrlKey: false, altKey: true, shiftKey: true, metaKey: false },
+      'dom-code',
+    ),
+    'Alt+Shift+MBTN_FORWARD',
   );
 });
 

--- a/src/settings/key-input.ts
+++ b/src/settings/key-input.ts
@@ -11,6 +11,14 @@ export interface KeyboardInputLike {
   metaKey: boolean;
 }
 
+export interface MouseInputLike {
+  button: number;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+  metaKey: boolean;
+}
+
 export interface MpvKeybindingRow {
   defaultKey: string;
   key: string;
@@ -77,6 +85,14 @@ const MPV_KEY_BY_CODE: Record<string, string> = {
   Slash: '/',
   Space: 'SPACE',
   Tab: 'TAB',
+};
+
+const MPV_MOUSE_BUTTON_BY_BUTTON: Record<number, string> = {
+  0: 'MBTN_LEFT',
+  1: 'MBTN_MID',
+  2: 'MBTN_RIGHT',
+  3: 'MBTN_BACK',
+  4: 'MBTN_FORWARD',
 };
 
 function commandEquals(a: Keybinding['command'], b: Keybinding['command']): boolean {
@@ -150,6 +166,24 @@ export function keyboardEventToConfigKey(
   if (input.shiftKey) parts.push('Shift');
   if (input.metaKey) parts.push('Meta');
   return [...parts, input.code].join('+');
+}
+
+export function mouseEventToConfigKey(input: MouseInputLike, mode: KeyInputMode): string | null {
+  if (mode !== 'dom-code') {
+    return null;
+  }
+
+  const key = MPV_MOUSE_BUTTON_BY_BUTTON[input.button];
+  if (!key) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  if (input.ctrlKey) parts.push('Ctrl');
+  if (input.altKey) parts.push('Alt');
+  if (input.shiftKey) parts.push('Shift');
+  if (input.metaKey) parts.push('Meta');
+  return [...parts, key].join('+');
 }
 
 export function createMpvKeybindingRows(

--- a/src/settings/settings-keybinding-controls.test.ts
+++ b/src/settings/settings-keybinding-controls.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldUseLearnedMouseBinding } from './settings-keybinding-controls';
+
+test('mouse key learning ignores primary left clicks in DOM-code mode', () => {
+  const learnButton = {};
+  const outsideTarget = {};
+
+  assert.equal(
+    shouldUseLearnedMouseBinding(
+      'MBTN_LEFT',
+      'dom-code',
+      { button: 0, target: outsideTarget } as MouseEvent,
+      learnButton as HTMLButtonElement,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldUseLearnedMouseBinding(
+      'MBTN_BACK',
+      'dom-code',
+      { button: 3, target: outsideTarget } as MouseEvent,
+      learnButton as HTMLButtonElement,
+    ),
+    true,
+  );
+});
+
+test('mouse key learning still ignores primary learn-button activation', () => {
+  const learnButton = {};
+
+  assert.equal(
+    shouldUseLearnedMouseBinding(
+      'MBTN_LEFT',
+      'dom-code',
+      { button: 0, target: learnButton } as MouseEvent,
+      learnButton as HTMLButtonElement,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldUseLearnedMouseBinding(
+      'MBTN_BACK',
+      'dom-code',
+      { button: 3, target: learnButton } as MouseEvent,
+      learnButton as HTMLButtonElement,
+    ),
+    true,
+  );
+});

--- a/src/settings/settings-keybinding-controls.ts
+++ b/src/settings/settings-keybinding-controls.ts
@@ -19,6 +19,18 @@ export function configureKeybindingControls(options: { requestRender: () => void
   requestRender = options.requestRender;
 }
 
+export function shouldUseLearnedMouseBinding(
+  next: string,
+  mode: KeyInputMode,
+  event: MouseEvent,
+  button: HTMLButtonElement,
+): boolean {
+  return Boolean(
+    !(event.target === button && event.button === 0) &&
+    !(mode === 'dom-code' && event.button === 0),
+  );
+}
+
 function startKeyLearning(
   button: HTMLButtonElement,
   mode: KeyInputMode,
@@ -60,7 +72,7 @@ function startKeyLearning(
   onBlur = (): void => stop();
   onMouseDown = (event: MouseEvent): void => {
     const next = mouseEventToConfigKey(event, mode);
-    if (next && !(event.target === button && event.button === 0)) {
+    if (next && shouldUseLearnedMouseBinding(next, mode, event, button)) {
       event.preventDefault();
       event.stopPropagation();
       stop();

--- a/src/settings/settings-keybinding-controls.ts
+++ b/src/settings/settings-keybinding-controls.ts
@@ -4,6 +4,7 @@ import {
   buildMpvKeybindingConfigValue,
   createMpvKeybindingRows,
   keyboardEventToConfigKey,
+  mouseEventToConfigKey,
   parseMpvCommandText,
   type KeyInputMode,
   type MpvKeybindingRow,
@@ -58,6 +59,15 @@ function startKeyLearning(
   };
   onBlur = (): void => stop();
   onMouseDown = (event: MouseEvent): void => {
+    const next = mouseEventToConfigKey(event, mode);
+    if (next && !(event.target === button && event.button === 0)) {
+      event.preventDefault();
+      event.stopPropagation();
+      stop();
+      onValue(next);
+      return;
+    }
+
     if (event.target !== button) {
       stop();
     }


### PR DESCRIPTION
## Summary

- Adds `MBTN_LEFT`, `MBTN_MID`, `MBTN_RIGHT`, `MBTN_BACK`, and `MBTN_FORWARD` as valid key codes in the `keybindings` config array
- Runtime `mousedown` handler in the overlay dispatches session bindings matched by mouse button code
- Settings UI key-capture now records mouse button presses (e.g. clicking side buttons while learning a binding)
- Lua plugin `KEY_NAME_MAP` extended so mouse button codes pass through to mpv unchanged
- Session-help modal displays human-readable names (`Mouse Back`, `Mouse Forward`, etc.)
- Mouse buttons intentionally restricted to `keybindings[]`; using them in `shortcuts` emits an `unsupported` warning
- Docs updated in `configuration.md` and `shortcuts.md` with button name reference and examples

## Testing

- `bun run test:fast` — unit tests cover `compileSessionBindings` (mouse binding parse, modifier combos, shortcuts rejection), `keyboardHandler` (mousedown dispatch), and `mouseEventToConfigKey`
- `scripts/test-plugin-session-bindings.lua` — Lua plugin test covers `MBTN_BACK` binding registration
- Manual: assign `MBTN_BACK` / `MBTN_FORWARD` in config; verify side-button presses trigger `sub-seek` in mpv
- Manual: open Settings keybinding capture, click a mouse side-button, confirm it records `MBTN_BACK`/`MBTN_FORWARD`
- `bun run docs:test && bun run docs:build` — docs build clean with new examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full mouse-button keybinding support (Left/Middle/Right/Back/Forward) with modifier combos, learning via the key-capture UI, and human-readable labels in shortcut help.
  * Mouse events can be converted into config key strings for dom-code mode.

* **Bug Fixes**
  * Mouse-button presses now correctly trigger configured session bindings, taking precedence over default click behavior.

* **Tests**
  * Added unit and integration tests exercising mouse-button binding, learning, and session dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->