### PR TITLE
fix(overlay): preserve visible state across playlist item transitions

### DIFF
--- a/changes/overlay-playlist-visible-state.md
+++ b/changes/overlay-playlist-visible-state.md
@@ -1,0 +1,4 @@
+type: fixed
+area: overlay
+
+- Kept the visible overlay active while mpv advances to the next playlist item, even when the next episode loads after the warm transition delay.

--- a/plugin/subminer/lifecycle.lua
+++ b/plugin/subminer/lifecycle.lua
@@ -51,6 +51,15 @@ function M.create(ctx)
 		return reason == "reload" or reason == "redirect"
 	end
 
+	local function has_next_playlist_item()
+		local playlist_count = mp.get_property_number("playlist-count")
+		local playlist_pos = mp.get_property_number("playlist-pos")
+		if type(playlist_count) ~= "number" or type(playlist_pos) ~= "number" then
+			return false
+		end
+		return playlist_count > 0 and playlist_pos >= 0 and playlist_pos < playlist_count - 1
+	end
+
 	local function clear_pending_visible_overlay_hide()
 		local timer = state.pending_visible_overlay_hide_timer
 		if timer and timer.kill then
@@ -63,6 +72,9 @@ function M.create(ctx)
 	local resolve_auto_start_visible_overlay_enabled
 
 	local function hide_visible_overlay_after_end_file()
+		if has_next_playlist_item() then
+			return
+		end
 		if state.visible_overlay_requested == true and not resolve_auto_start_visible_overlay_enabled() then
 			return
 		end

--- a/scripts/test-plugin-start-gate.lua
+++ b/scripts/test-plugin-start-gate.lua
@@ -69,6 +69,12 @@ local function run_plugin_scenario(config)
 			if name == "osd-height" then
 				return config.osd_height or 720
 			end
+			if name == "playlist-count" then
+				return config.playlist_count
+			end
+			if name == "playlist-pos" then
+				return config.playlist_pos
+			end
 			return nil
 		end
 
@@ -624,6 +630,46 @@ do
 	assert_true(
 		count_start_calls(recorded.async_calls) == 1,
 		"warm playlist visibility reuse should not issue another --start command"
+	)
+end
+
+do
+	local scenario = {
+		process_list = "",
+		defer_timeouts = true,
+		option_overrides = {
+			binary_path = binary_path,
+			auto_start = "yes",
+			auto_start_visible_overlay = "yes",
+			auto_start_pause_until_ready = "yes",
+			socket_path = "/tmp/subminer-socket",
+		},
+		input_ipc_server = "/tmp/subminer-socket",
+		path = "/media/slow-episode-01.mkv",
+		media_title = "Slow Episode 1",
+		playlist_count = 2,
+		playlist_pos = 0,
+		files = {
+			[binary_path] = true,
+		},
+	}
+	local recorded, err = run_plugin_scenario(scenario)
+	assert_true(recorded ~= nil, "plugin failed to load for slow warm playlist visibility scenario: " .. tostring(err))
+	fire_event(recorded, "file-loaded")
+	recorded.script_messages["subminer-autoplay-ready"]()
+	fire_event(recorded, "end-file", { reason = "eof" })
+	fire_pending_timeouts(recorded)
+	scenario.path = "/media/slow-episode-02.mkv"
+	scenario.media_title = "Slow Episode 2"
+	scenario.playlist_pos = 1
+	fire_event(recorded, "file-loaded")
+	assert_true(
+		count_control_calls(recorded.async_calls, "--hide-visible-overlay") == 0,
+		"slow playlist advance should preserve visible overlay state while the next episode is pending"
+	)
+	assert_true(
+		count_start_calls(recorded.async_calls) == 1,
+		"slow playlist visibility reuse should not issue another --start command"
 	)
 end
 


### PR DESCRIPTION
## Summary

- Overlay no longer hides when mpv advances to the next playlist item via EOF
- Added `has_next_playlist_item()` guard in `hide_visible_overlay_after_end_file()` — skips teardown when a next item exists
- Added changelog entry under `changes/overlay-playlist-visible-state.md`

## Testing

- New test scenario in `scripts/test-plugin-start-gate.lua`: simulates a two-item playlist with `auto_start_visible_overlay=yes` and a slow warm transition delay; asserts no `--hide-visible-overlay` call is issued on EOF and no extra `--start` command fires when the next episode loads
- Manual: open a playlist of two episodes with `auto_start_visible_overlay=yes`; confirm overlay remains visible after the first episode ends and the second begins loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed overlay visibility when automatically advancing to the next item in a playlist.

* **Tests**
  * Added regression tests for playlist advancement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->