### PR TITLE
fix(stats): parse v3 reading-aware known-word cache in stats server

### DIFF
--- a/changes/stats-known-words-v3-cache.md
+++ b/changes/stats-known-words-v3-cache.md
@@ -1,0 +1,4 @@
+type: fixed
+area: stats
+
+- Session known-word counts no longer show 0 everywhere. The stats server's known-word cache parser only understood the v1/v2 cache formats, so after the reading-aware v3 cache upgrade it silently treated the cache as missing; it now flattens v3 note entries into the headword set.

--- a/src/core/services/__tests__/stats-server.test.ts
+++ b/src/core/services/__tests__/stats-server.test.ts
@@ -521,6 +521,44 @@ describe('stats server API routes', () => {
     });
   });
 
+  it('GET /api/stats/sessions enriches known-word metrics from a v3 reading-aware cache', async () => {
+    await withTempDir(async (dir) => {
+      const cachePath = path.join(dir, 'known-words.json');
+      fs.writeFileSync(
+        cachePath,
+        JSON.stringify({
+          version: 3,
+          refreshedAtMs: 1,
+          scope: 'deck:test',
+          notes: {
+            '101': [{ word: 'する', reading: 'する' }],
+            '102': [{ word: '猫', reading: null }],
+          },
+        }),
+      );
+
+      const app = createStatsApp(
+        createMockTracker({
+          getSessionWordsByLine: async (sessionId: number) =>
+            sessionId === 1
+              ? [
+                  { lineIndex: 1, headword: 'する', occurrenceCount: 2 },
+                  { lineIndex: 2, headword: '未知', occurrenceCount: 1 },
+                ]
+              : [],
+        }),
+        { knownWordCachePath: cachePath },
+      );
+
+      const res = await app.request('/api/stats/sessions?limit=5');
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      const first = body[0];
+      assert.equal(first.knownWordsSeen, 2);
+      assert.equal(first.knownWordRate, 66.7);
+    });
+  });
+
   it('GET /api/stats/sessions/:id/events forwards event type filters to the tracker', async () => {
     let seenSessionId = 0;
     let seenLimit = 0;

--- a/src/core/services/stats-server.ts
+++ b/src/core/services/stats-server.ts
@@ -261,9 +261,24 @@ function loadKnownWordsSet(cachePath: string | undefined): Set<string> | null {
     const raw = JSON.parse(readFileSync(cachePath, 'utf-8')) as {
       version?: number;
       words?: string[];
+      notes?: Record<string, Array<{ word?: unknown; reading?: unknown }>>;
     };
     if ((raw.version === 1 || raw.version === 2) && Array.isArray(raw.words)) {
       return new Set(raw.words);
+    }
+    // v3 stores reading-aware entries per note; stats rows only carry
+    // headwords, so flatten to a word set (reading-agnostic, fail-open).
+    if (raw.version === 3 && raw.notes && typeof raw.notes === 'object') {
+      const words = new Set<string>();
+      for (const entries of Object.values(raw.notes)) {
+        if (!Array.isArray(entries)) continue;
+        for (const entry of entries) {
+          if (entry && typeof entry.word === 'string' && entry.word) {
+            words.add(entry.word);
+          }
+        }
+      }
+      return words;
     }
   } catch {
     /* ignore */


### PR DESCRIPTION
## Summary

- Session known-word counts showed 0 everywhere after the reading-aware v3 cache upgrade (#147)
- Root cause: `loadKnownWordsSet` in `stats-server.ts` only handled v1/v2 cache formats (`words: string[]`); v3 uses a `notes` map of `{word, reading}` entry arrays, so it silently returned `null` and skipped enrichment
- Fix flattens v3 `notes` entries into a plain headword `Set<string>` (reading-agnostic, matching how stats DB rows store headwords)
- Adds changelog entry under `changes/`

## Testing

- New unit test `GET /api/stats/sessions enriches known-word metrics from a v3 reading-aware cache` in `stats-server.test.ts`: writes a v3 cache fixture, mounts the app, and asserts `knownWordsSeen` and `knownWordRate` are non-zero
- Verified `knownWordsSeen: 2` and `knownWordRate: 66.7` for a session with one known word (`する`) and one unknown word (`未知`) out of 3 total occurrences
- Existing v1/v2 cache tests continue to pass (no regression to prior format handling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stats calculations to work with the newer reading-aware cache format.
  * “Known words” metrics now stay accurate when session data is stored in the latest cache structure.
  * Added coverage for the updated cache format to ensure session stats continue to report expected values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->