### PR TITLE
test(tokenizer): add golden-file regression corpus with 11 fixtures

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ release
 coverage
 vendor
 *.log
+src/core/services/tokenizer/__fixtures__/golden/*.json

--- a/changes/golden-tokenizer-corpus.md
+++ b/changes/golden-tokenizer-corpus.md
@@ -1,0 +1,7 @@
+type: internal
+area: tokenizer
+
+- Added a golden-file regression corpus for the tokenizer/annotation pipeline: recorded Yomitan backend responses and MeCab tokens replay through the real tokenizeSubtitle pipeline in bun tests without Electron or dictionaries.
+- Added `record-tokenizer-fixture:electron` script to capture new fixtures from a live Yomitan/MeCab session, with flags for known words, JLPT levels, and annotation toggles.
+- Seeded eleven fixtures covering the #147–#156 regression classes (grammar-helper suppression, lexical くれる, kanji non-independent nouns, N+1 targeting, reading collisions, unparsed runs, ordinal/honorific prefixes).
+- Added `compare-yomitan-api:electron` script that diffs SubMiner tokenization against a stock Yomitan instance via the yomitan-api bridge (segmentation, readings, headword forms).

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "get-frequency:electron": "bun run build:yomitan && bun build scripts/get_frequency.ts --format=cjs --target=node --outfile dist/scripts/get_frequency.js --external electron && env -u ELECTRON_RUN_AS_NODE electron dist/scripts/get_frequency.js --pretty --color-top-x 10000 --yomitan-user-data ~/.config/SubMiner --colorized-line",
     "test-yomitan-parser": "bun run scripts/test-yomitan-parser.ts",
     "test-yomitan-parser:electron": "bun run build:yomitan && bun build scripts/test-yomitan-parser.ts --format=cjs --target=node --outfile dist/scripts/test-yomitan-parser.js --external electron && env -u ELECTRON_RUN_AS_NODE electron dist/scripts/test-yomitan-parser.js",
+    "record-tokenizer-fixture:electron": "bun run build:yomitan && bun build scripts/record-tokenizer-fixture.ts --format=cjs --target=node --outfile dist/scripts/record-tokenizer-fixture.js --external electron && env -u ELECTRON_RUN_AS_NODE electron dist/scripts/record-tokenizer-fixture.js",
+    "compare-yomitan-api:electron": "bun run build:yomitan && bun build scripts/compare-yomitan-api.ts --format=cjs --target=node --outfile dist/scripts/compare-yomitan-api.js --external electron && env -u ELECTRON_RUN_AS_NODE electron dist/scripts/compare-yomitan-api.js",
     "build:yomitan": "bun scripts/build-yomitan.mjs",
     "build:assets": "bun scripts/prepare-build-assets.mjs",
     "build:launcher": "bun build ./launcher/main.ts --target=bun --packages=bundle --banner='#!/usr/bin/env bun' --outfile=dist/launcher/subminer",

--- a/scripts/compare-yomitan-api.test.ts
+++ b/scripts/compare-yomitan-api.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync('scripts/compare-yomitan-api.ts', 'utf8');
+
+test('creates the configured Yomitan user-data directory before Electron uses it', () => {
+  const setPathIndex = source.indexOf(
+    "electronModule.app.setPath('userData', options.yomitanUserDataPath)",
+  );
+  assert.notEqual(setPathIndex, -1);
+
+  const mkdirIndex = source.lastIndexOf(
+    'fs.mkdirSync(options.yomitanUserDataPath, { recursive: true })',
+    setPathIndex,
+  );
+  assert.ok(mkdirIndex > -1, 'must create the user-data directory');
+  assert.ok(mkdirIndex < setPathIndex, 'must create the directory before app.setPath');
+});
+
+test('lets output drain by using exitCode in the top-level completion handlers', () => {
+  const completionHandlers = source.slice(source.lastIndexOf('\nmain()'));
+  assert.match(completionHandlers, /process\.exitCode = process\.exitCode \?\? 0/);
+  assert.match(completionHandlers, /process\.exitCode = 1/);
+  assert.doesNotMatch(completionHandlers, /process\.exit\(/);
+});

--- a/scripts/compare-yomitan-api.ts
+++ b/scripts/compare-yomitan-api.ts
@@ -10,6 +10,8 @@ import { resolveYomitanExtensionPath as resolveBuiltYomitanExtensionPath } from 
 import { MecabTokenizer } from '../src/mecab-tokenizer.js';
 import type { MergedToken } from '../src/types.js';
 
+import { fetchYomitanApi } from './yomitan-api-request.js';
+
 // Compares SubMiner's full tokenization pipeline against a stock Yomitan
 // instance reached through the yomitan-api native-messaging bridge
 // (https://github.com/yomidevs/yomitan-api, default http://127.0.0.1:19633).
@@ -264,7 +266,7 @@ async function fetchApiTokens(
   text: string,
   scanLength: number,
 ): Promise<MergedToken[] | null> {
-  const response = await fetch(`${apiUrl}/tokenize`, {
+  const response = await fetchYomitanApi(`${apiUrl}/tokenize`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ text, scanLength, parser: 'scanning-parser' }),
@@ -445,7 +447,7 @@ async function main(): Promise<void> {
 
   // Fail fast with a clear message when the bridge is not running.
   try {
-    const probe = await fetch(`${options.apiUrl}/serverVersion`, {
+    const probe = await fetchYomitanApi(`${options.apiUrl}/serverVersion`, {
       method: 'POST',
       body: '{}',
     });
@@ -473,6 +475,7 @@ async function main(): Promise<void> {
   }
 
   if (typeof electronModule.app.setPath === 'function') {
+    fs.mkdirSync(options.yomitanUserDataPath, { recursive: true });
     electronModule.app.setPath('userData', options.yomitanUserDataPath);
   }
   await electronModule.app.whenReady();
@@ -578,9 +581,9 @@ async function main(): Promise<void> {
 
 main()
   .then(() => {
-    process.exit(process.exitCode ?? 0);
+    process.exitCode = process.exitCode ?? 0;
   })
   .catch((error) => {
     console.error(`Error: ${(error as Error).message}`);
-    process.exit(1);
+    process.exitCode = 1;
   });

--- a/scripts/compare-yomitan-api.ts
+++ b/scripts/compare-yomitan-api.ts
@@ -1,0 +1,586 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { createTokenizerDepsRuntime, tokenizeSubtitle } from '../src/core/services/tokenizer.js';
+import { selectYomitanParseTokens } from '../src/core/services/tokenizer/parser-selection-stage.js';
+import { enrichTokensWithMecabPos1 } from '../src/core/services/tokenizer/parser-enrichment-stage.js';
+import { resolveYomitanExtensionPath as resolveBuiltYomitanExtensionPath } from '../src/core/services/yomitan-extension-paths.js';
+import { MecabTokenizer } from '../src/mecab-tokenizer.js';
+import type { MergedToken } from '../src/types.js';
+
+// Compares SubMiner's full tokenization pipeline against a stock Yomitan
+// instance reached through the yomitan-api native-messaging bridge
+// (https://github.com/yomidevs/yomitan-api, default http://127.0.0.1:19633).
+// The API response is raw parseText output; it is mapped through SubMiner's
+// own selectYomitanParseTokens so both sides share identical mapping
+// semantics and the diff isolates real segmentation/headword divergence.
+
+const DEFAULT_YOMITAN_USER_DATA_PATH = path.join(os.homedir(), '.config', 'SubMiner');
+const DEFAULT_API_URL = 'http://127.0.0.1:19633';
+const DEFAULT_SCAN_LENGTH = 40;
+const FIXTURE_DIR = path.join('src', 'core', 'services', 'tokenizer', '__fixtures__', 'golden');
+
+interface CliOptions {
+  sentences: string[];
+  fromFixtures: boolean;
+  apiUrl: string;
+  scanLength: number;
+  emitJson: boolean;
+  nameMatch: boolean;
+  yomitanExtensionPath?: string;
+  yomitanUserDataPath: string;
+  mecabCommand?: string;
+  mecabDictionaryPath?: string;
+}
+
+function printUsage(): void {
+  process.stdout.write(`Usage:
+  bun run compare-yomitan-api:electron -- [options] [sentence ...]
+
+  Compares SubMiner tokenization against a stock Yomitan instance via the
+  yomitan-api bridge. Without sentences, compares every golden-corpus fixture
+  text plus any --file lines.
+
+  --from-fixtures            Include golden-corpus fixture texts (default when
+                             no sentences are given).
+  --file <path>              Read additional sentences, one per line.
+  --api-url <url>            yomitan-api base URL (default: ${DEFAULT_API_URL}).
+  --scan-length <n>          Scan length for the API request (default: ${DEFAULT_SCAN_LENGTH}).
+  --name-match               Keep SubMiner's character-name pre-pass enabled.
+                             Off by default: stock Yomitan has no name regions,
+                             so it would only add noise to the diff.
+  --json                     Emit machine-readable JSON instead of a report.
+  --yomitan-extension <path> Path to built Yomitan extension directory.
+  --yomitan-user-data <path> Electron userData directory (default: ~/.config/SubMiner).
+  --mecab-command <path>     MeCab binary (default: mecab).
+  --mecab-dictionary <path>  MeCab dictionary directory.
+  -h, --help                 Show usage.
+
+  Exits 1 when any sentence diverges, 0 when everything matches.
+`);
+}
+
+function requireValue(args: string[], flag: string): string {
+  const next = args.shift();
+  if (!next) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return next;
+}
+
+function parseCliArgs(argv: string[]): CliOptions {
+  const args = [...argv];
+  const sentences: string[] = [];
+  let fromFixtures = false;
+  let apiUrl = DEFAULT_API_URL;
+  let scanLength = DEFAULT_SCAN_LENGTH;
+  let emitJson = false;
+  let nameMatch = false;
+  let yomitanExtensionPath: string | undefined;
+  let yomitanUserDataPath = DEFAULT_YOMITAN_USER_DATA_PATH;
+  let mecabCommand: string | undefined;
+  let mecabDictionaryPath: string | undefined;
+
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (!arg) break;
+
+    if (arg === '--help' || arg === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+    if (arg === '--from-fixtures') {
+      fromFixtures = true;
+      continue;
+    }
+    if (arg === '--file') {
+      const filePath = requireValue(args, arg);
+      const lines = fs
+        .readFileSync(filePath, 'utf8')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      sentences.push(...lines);
+      continue;
+    }
+    if (arg === '--api-url') {
+      apiUrl = requireValue(args, arg).replace(/\/$/, '');
+      continue;
+    }
+    if (arg === '--scan-length') {
+      const value = Number(requireValue(args, arg));
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error('Invalid --scan-length value');
+      }
+      scanLength = value;
+      continue;
+    }
+    if (arg === '--json') {
+      emitJson = true;
+      continue;
+    }
+    if (arg === '--name-match') {
+      nameMatch = true;
+      continue;
+    }
+    if (arg === '--yomitan-extension') {
+      yomitanExtensionPath = requireValue(args, arg);
+      continue;
+    }
+    if (arg === '--yomitan-user-data') {
+      yomitanUserDataPath = requireValue(args, arg);
+      continue;
+    }
+    if (arg === '--mecab-command') {
+      mecabCommand = requireValue(args, arg);
+      continue;
+    }
+    if (arg === '--mecab-dictionary') {
+      mecabDictionaryPath = requireValue(args, arg);
+      continue;
+    }
+    if (arg.startsWith('-') && arg !== '-') {
+      throw new Error(`Unknown flag: ${arg}`);
+    }
+    sentences.push(arg);
+  }
+
+  if (sentences.length === 0) {
+    fromFixtures = true;
+  }
+
+  return {
+    sentences,
+    fromFixtures,
+    apiUrl,
+    scanLength,
+    emitJson,
+    nameMatch,
+    yomitanExtensionPath,
+    yomitanUserDataPath,
+    mecabCommand,
+    mecabDictionaryPath,
+  };
+}
+
+function loadFixtureSentences(): string[] {
+  if (!fs.existsSync(FIXTURE_DIR)) {
+    return [];
+  }
+  return fs
+    .readdirSync(FIXTURE_DIR)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort()
+    .map((entry) => {
+      const fixture = JSON.parse(fs.readFileSync(path.join(FIXTURE_DIR, entry), 'utf8')) as {
+        input?: { text?: string };
+      };
+      return fixture.input?.text ?? '';
+    })
+    .filter((text) => text.length > 0);
+}
+
+function normalizeTokenizerText(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/\\N/g, '\n')
+    .replace(/\\n/g, '\n')
+    .trim()
+    .replace(/\n/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+interface FuriganaChunk {
+  startPos: number;
+  endPos: number;
+  reading: string;
+  headword: string;
+}
+
+// Walk the raw parseText content the same way the parse-result mapper does
+// (whole segments, char offsets accumulated across lines) and capture, per
+// chunk, the effective reading (kana chunks read as themselves) and the first
+// dictionary headword term. The mapper's token spans are authoritative for
+// grouping; these chunks supply the complete reading/lemma the legacy mapper
+// does not synthesize.
+function collectFuriganaChunks(parseResults: unknown): FuriganaChunk[] {
+  const chunks: FuriganaChunk[] = [];
+  if (!Array.isArray(parseResults)) {
+    return chunks;
+  }
+  const content = (parseResults[0] as { content?: unknown } | undefined)?.content;
+  if (!Array.isArray(content)) {
+    return chunks;
+  }
+  let charOffset = 0;
+  for (const line of content) {
+    if (!Array.isArray(line)) {
+      continue;
+    }
+    for (const segment of line as Array<Record<string, unknown>>) {
+      const text = typeof segment?.text === 'string' ? segment.text : '';
+      if (!text) {
+        continue;
+      }
+      const reading =
+        typeof segment.reading === 'string' && segment.reading.length > 0 ? segment.reading : text;
+      let headword = '';
+      const headwords = segment.headwords;
+      if (Array.isArray(headwords)) {
+        for (const row of headwords) {
+          const first = Array.isArray(row) ? (row[0] as { term?: unknown } | undefined) : undefined;
+          if (first && typeof first.term === 'string' && first.term.trim().length > 0) {
+            headword = first.term.trim();
+            break;
+          }
+        }
+      }
+      chunks.push({ startPos: charOffset, endPos: charOffset + text.length, reading, headword });
+      charOffset += text.length;
+    }
+  }
+  return chunks;
+}
+
+function overlayChunkMetadata(tokens: MergedToken[], chunks: FuriganaChunk[]): MergedToken[] {
+  return tokens.map((token) => {
+    const covered = chunks.filter(
+      (chunk) => chunk.startPos >= token.startPos && chunk.endPos <= token.endPos,
+    );
+    if (covered.length === 0) {
+      return token;
+    }
+    const reading = covered.map((chunk) => chunk.reading).join('');
+    const headword = covered.find((chunk) => chunk.headword)?.headword ?? token.surface;
+    return { ...token, reading, headword };
+  });
+}
+
+async function fetchApiTokens(
+  apiUrl: string,
+  text: string,
+  scanLength: number,
+): Promise<MergedToken[] | null> {
+  const response = await fetch(`${apiUrl}/tokenize`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text, scanLength, parser: 'scanning-parser' }),
+  });
+  if (!response.ok) {
+    throw new Error(`yomitan-api /tokenize responded ${response.status}`);
+  }
+  const parseResults = (await response.json()) as unknown;
+  const tokens = selectYomitanParseTokens(parseResults, () => false, 'headword');
+  if (!tokens) {
+    return tokens;
+  }
+  return overlayChunkMetadata(tokens, collectFuriganaChunks(parseResults));
+}
+
+interface ComparedToken {
+  surface: string;
+  reading: string;
+  headword: string;
+  startPos: number;
+  endPos: number;
+  frequencyRank?: number;
+}
+
+function toComparedTokens(tokens: MergedToken[] | null): ComparedToken[] {
+  return (tokens ?? []).map((token) => ({
+    surface: token.surface,
+    reading: token.reading,
+    headword: token.headword,
+    startPos: token.startPos,
+    endPos: token.endPos,
+    frequencyRank: token.frequencyRank,
+  }));
+}
+
+interface MismatchRegion {
+  subminer: ComparedToken[];
+  yomitan: ComparedToken[];
+}
+
+interface PairDiff {
+  surface: string;
+  field: 'headword' | 'reading';
+  subminer: string;
+  yomitan: string;
+}
+
+interface SentenceComparison {
+  text: string;
+  subminerTokens: ComparedToken[];
+  yomitanTokens: ComparedToken[];
+  segmentationMatches: boolean;
+  mismatchRegions: MismatchRegion[];
+  pairDiffs: PairDiff[];
+  error?: string;
+}
+
+// Walk both token lists in span order. Tokens whose [startPos, endPos) agree
+// are paired; disagreeing runs are grouped until the boundaries realign.
+function compareTokenLists(
+  subminer: ComparedToken[],
+  yomitan: ComparedToken[],
+): Pick<SentenceComparison, 'segmentationMatches' | 'mismatchRegions' | 'pairDiffs'> {
+  const mismatchRegions: MismatchRegion[] = [];
+  const pairDiffs: PairDiff[] = [];
+  let i = 0;
+  let j = 0;
+
+  while (i < subminer.length || j < yomitan.length) {
+    const a = subminer[i];
+    const b = yomitan[j];
+    if (a && b && a.startPos === b.startPos && a.endPos === b.endPos) {
+      if (a.headword !== b.headword) {
+        pairDiffs.push({
+          surface: a.surface,
+          field: 'headword',
+          subminer: a.headword,
+          yomitan: b.headword,
+        });
+      }
+      // An empty reading means "reads as its surface" (kana tokens, unparsed
+      // runs) — normalize before comparing.
+      if ((a.reading || a.surface) !== (b.reading || b.surface)) {
+        pairDiffs.push({
+          surface: a.surface,
+          field: 'reading',
+          subminer: a.reading,
+          yomitan: b.reading,
+        });
+      }
+      i += 1;
+      j += 1;
+      continue;
+    }
+
+    const region: MismatchRegion = { subminer: [], yomitan: [] };
+    let aEnd = a ? a.startPos : Number.MAX_SAFE_INTEGER;
+    let bEnd = b ? b.startPos : Number.MAX_SAFE_INTEGER;
+    do {
+      if (aEnd <= bEnd && i < subminer.length) {
+        const token = subminer[i];
+        if (token) {
+          region.subminer.push(token);
+          aEnd = token.endPos;
+        }
+        i += 1;
+      } else if (j < yomitan.length) {
+        const token = yomitan[j];
+        if (token) {
+          region.yomitan.push(token);
+          bEnd = token.endPos;
+        }
+        j += 1;
+      } else {
+        break;
+      }
+    } while (aEnd !== bEnd && (i < subminer.length || j < yomitan.length));
+    mismatchRegions.push(region);
+  }
+
+  return {
+    segmentationMatches: mismatchRegions.length === 0,
+    mismatchRegions,
+    pairDiffs,
+  };
+}
+
+function renderTokenRun(tokens: ComparedToken[]): string {
+  if (tokens.length === 0) {
+    return '(no tokens)';
+  }
+  return tokens.map((token) => token.surface).join('|');
+}
+
+function renderReport(comparisons: SentenceComparison[]): void {
+  let divergent = 0;
+  for (const comparison of comparisons) {
+    const clean =
+      !comparison.error && comparison.segmentationMatches && comparison.pairDiffs.length === 0;
+    if (!clean) {
+      divergent += 1;
+    }
+    process.stdout.write(`\n${clean ? 'MATCH' : 'DIFF '} ${comparison.text}\n`);
+    if (comparison.error) {
+      process.stdout.write(`  error: ${comparison.error}\n`);
+      continue;
+    }
+    if (clean) {
+      process.stdout.write(
+        `  ${comparison.subminerTokens.length} tokens: ${renderTokenRun(comparison.subminerTokens)}\n`,
+      );
+      continue;
+    }
+    if (!comparison.segmentationMatches) {
+      process.stdout.write('  segmentation:\n');
+      for (const region of comparison.mismatchRegions) {
+        process.stdout.write(`    subminer: ${renderTokenRun(region.subminer)}\n`);
+        process.stdout.write(`    yomitan:  ${renderTokenRun(region.yomitan)}\n`);
+      }
+    }
+    for (const diff of comparison.pairDiffs) {
+      process.stdout.write(
+        `  ${diff.surface}: ${diff.field} "${diff.subminer}" (subminer) vs "${diff.yomitan}" (yomitan)\n`,
+      );
+    }
+  }
+  process.stdout.write(
+    `\n${comparisons.length - divergent}/${comparisons.length} sentences match stock Yomitan\n`,
+  );
+}
+
+async function main(): Promise<void> {
+  const options = parseCliArgs(process.argv.slice(2));
+  const sentences = [...(options.fromFixtures ? loadFixtureSentences() : []), ...options.sentences];
+  if (sentences.length === 0) {
+    throw new Error('No sentences to compare (no fixtures found and none provided).');
+  }
+
+  // Fail fast with a clear message when the bridge is not running.
+  try {
+    const probe = await fetch(`${options.apiUrl}/serverVersion`, {
+      method: 'POST',
+      body: '{}',
+    });
+    if (!probe.ok) {
+      throw new Error(`status ${probe.status}`);
+    }
+  } catch (error) {
+    throw new Error(
+      `yomitan-api is not reachable at ${options.apiUrl} (${(error as Error).message}). ` +
+        'Ensure the browser is running and "Enable Yomitan API" is on in Yomitan settings.',
+    );
+  }
+
+  const electronModule = await import('electron').catch(() => null);
+  if (!electronModule?.app || !electronModule?.session) {
+    throw new Error('Electron runtime required; run via `bun run compare-yomitan-api:electron`.');
+  }
+
+  const mecabTokenizer = new MecabTokenizer({
+    mecabCommand: options.mecabCommand,
+    dictionaryPath: options.mecabDictionaryPath,
+  });
+  if (!(await mecabTokenizer.checkAvailability())) {
+    throw new Error('MeCab is not available on this system.');
+  }
+
+  if (typeof electronModule.app.setPath === 'function') {
+    electronModule.app.setPath('userData', options.yomitanUserDataPath);
+  }
+  await electronModule.app.whenReady();
+
+  const extensionPath = resolveBuiltYomitanExtensionPath({
+    explicitPath: options.yomitanExtensionPath,
+    cwd: process.cwd(),
+  });
+  if (!extensionPath) {
+    throw new Error('No built Yomitan extension found; run `bun run build:yomitan` first.');
+  }
+  const extension = await electronModule.session.defaultSession.loadExtension(extensionPath, {
+    allowFileAccess: true,
+  });
+
+  let parserWindow: Electron.BrowserWindow | null = null;
+  let parserReadyPromise: Promise<void> | null = null;
+  let parserInitPromise: Promise<boolean> | null = null;
+
+  const runtimeDeps = createTokenizerDepsRuntime({
+    getYomitanExt: () => extension,
+    getYomitanParserWindow: () => parserWindow,
+    setYomitanParserWindow: (window) => {
+      parserWindow = window;
+    },
+    getYomitanParserReadyPromise: () => parserReadyPromise,
+    setYomitanParserReadyPromise: (promise) => {
+      parserReadyPromise = promise;
+    },
+    getYomitanParserInitPromise: () => parserInitPromise,
+    setYomitanParserInitPromise: (promise) => {
+      parserInitPromise = promise;
+    },
+    isKnownWord: () => false,
+    getKnownWordMatchMode: () => 'headword',
+    getJlptLevel: () => null,
+    getNameMatchEnabled: () => options.nameMatch,
+    getMecabTokenizer: () => ({
+      tokenize: (text: string) => mecabTokenizer.tokenize(text),
+    }),
+  });
+  const deps = {
+    ...runtimeDeps,
+    enrichTokensWithMecab: async (
+      tokens: Parameters<typeof enrichTokensWithMecabPos1>[0],
+      mecabTokens: Parameters<typeof enrichTokensWithMecabPos1>[1],
+    ) => enrichTokensWithMecabPos1(tokens, mecabTokens),
+  };
+
+  const comparisons: SentenceComparison[] = [];
+  try {
+    for (const sentence of sentences) {
+      const text = normalizeTokenizerText(sentence);
+      try {
+        const [subtitleData, apiTokens] = await Promise.all([
+          tokenizeSubtitle(text, deps),
+          fetchApiTokens(options.apiUrl, text, options.scanLength),
+        ]);
+        const subminerTokens = toComparedTokens(subtitleData.tokens);
+        const yomitanTokens = toComparedTokens(apiTokens);
+        comparisons.push({
+          text,
+          subminerTokens,
+          yomitanTokens,
+          ...compareTokenLists(subminerTokens, yomitanTokens),
+        });
+      } catch (error) {
+        comparisons.push({
+          text,
+          subminerTokens: [],
+          yomitanTokens: [],
+          segmentationMatches: false,
+          mismatchRegions: [],
+          pairDiffs: [],
+          error: (error as Error).message,
+        });
+      }
+    }
+  } finally {
+    if (parserWindow) {
+      const window = parserWindow as Electron.BrowserWindow;
+      if (!window.isDestroyed()) {
+        window.destroy();
+      }
+    }
+    electronModule.app.quit();
+  }
+
+  if (options.emitJson) {
+    process.stdout.write(`${JSON.stringify(comparisons, null, 2)}\n`);
+  } else {
+    renderReport(comparisons);
+  }
+
+  const anyDivergence = comparisons.some(
+    (comparison) =>
+      comparison.error !== undefined ||
+      !comparison.segmentationMatches ||
+      comparison.pairDiffs.length > 0,
+  );
+  process.exitCode = anyDivergence ? 1 : 0;
+}
+
+main()
+  .then(() => {
+    process.exit(process.exitCode ?? 0);
+  })
+  .catch((error) => {
+    console.error(`Error: ${(error as Error).message}`);
+    process.exit(1);
+  });

--- a/scripts/record-tokenizer-fixture.ts
+++ b/scripts/record-tokenizer-fixture.ts
@@ -1,0 +1,496 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { createTokenizerDepsRuntime, tokenizeSubtitle } from '../src/core/services/tokenizer.js';
+import {
+  buildFixtureLookups,
+  classifyInjectedScript,
+  fixtureConfigGetters,
+  hashInjectedScript,
+  projectGoldenTokens,
+  pruneGoldenMessages,
+} from '../src/core/services/tokenizer/golden-corpus-harness.js';
+import type {
+  GoldenFixture,
+  GoldenFixtureConfig,
+  GoldenRecordedMessage,
+  GoldenRecordedScript,
+} from '../src/core/services/tokenizer/golden-corpus-harness.js';
+import { enrichTokensWithMecabPos1 } from '../src/core/services/tokenizer/parser-enrichment-stage.js';
+import { resolveYomitanExtensionPath as resolveBuiltYomitanExtensionPath } from '../src/core/services/yomitan-extension-paths.js';
+import { MecabTokenizer } from '../src/mecab-tokenizer.js';
+import type { JlptLevel, Token } from '../src/types.js';
+
+const DEFAULT_YOMITAN_USER_DATA_PATH = path.join(os.homedir(), '.config', 'SubMiner');
+const DEFAULT_FIXTURE_DIR = path.join(
+  'src',
+  'core',
+  'services',
+  'tokenizer',
+  '__fixtures__',
+  'golden',
+);
+const JLPT_LEVELS: ReadonlySet<string> = new Set(['N1', 'N2', 'N3', 'N4', 'N5']);
+
+interface CliOptions {
+  name: string;
+  text: string;
+  description?: string;
+  issueRefs: string[];
+  config: GoldenFixtureConfig;
+  outDir: string;
+  force: boolean;
+  yomitanExtensionPath?: string;
+  yomitanUserDataPath: string;
+  mecabCommand?: string;
+  mecabDictionaryPath?: string;
+}
+
+function printUsage(): void {
+  process.stdout.write(`Usage:
+  bun run record-tokenizer-fixture:electron -- --name <slug> [options] <subtitle text>
+
+  Records a golden tokenizer fixture: raw Yomitan backend responses, raw MeCab
+  tokens, and the annotated tokens the full pipeline produced for the text.
+  Review the "expected" block before committing — it becomes the assertion.
+
+  --name <slug>              Fixture name (file becomes <slug>.json). Required.
+  --description <text>       What behavior this fixture pins down.
+  --issue <ref>              Related issue/PR ref, repeatable (e.g. --issue "#156").
+  --known-word <w[:reading]> Mark a word known, repeatable.
+  --jlpt <term=level>        JLPT level for a term, repeatable (level N1..N5).
+  --local-frequency <t=rank> Local frequency-dictionary rank, repeatable.
+  --match-mode <mode>        Known-word match mode: headword|surface.
+  --min-sentence-words <n>   Minimum sentence words for N+1.
+  --no-known-words           Disable known-word annotation.
+  --no-nplusone              Disable N+1 targeting.
+  --no-jlpt                  Disable JLPT annotation.
+  --no-name-match            Disable character-name matching.
+  --no-frequency             Disable frequency annotation.
+  --out-dir <path>           Fixture directory (default: ${DEFAULT_FIXTURE_DIR}).
+  --force                    Overwrite an existing fixture file.
+  --yomitan-extension <path> Path to built Yomitan extension directory.
+  --yomitan-user-data <path> Electron userData directory (default: ~/.config/SubMiner).
+  --mecab-command <path>     MeCab binary (default: mecab).
+  --mecab-dictionary <path>  MeCab dictionary directory.
+  -h, --help                 Show usage.
+`);
+}
+
+function requireValue(args: string[], flag: string): string {
+  const next = args.shift();
+  if (!next) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return next;
+}
+
+function parseCliArgs(argv: string[]): CliOptions {
+  const args = [...argv];
+  const inputParts: string[] = [];
+  const issueRefs: string[] = [];
+  const knownWords: GoldenFixtureConfig['knownWords'] = [];
+  const jlptLevels: Record<string, JlptLevel> = {};
+  const localFrequencyRanks: Record<string, number> = {};
+  const config: GoldenFixtureConfig = {};
+  let name: string | undefined;
+  let description: string | undefined;
+  let outDir = DEFAULT_FIXTURE_DIR;
+  let force = false;
+  let yomitanExtensionPath: string | undefined;
+  let yomitanUserDataPath = DEFAULT_YOMITAN_USER_DATA_PATH;
+  let mecabCommand: string | undefined;
+  let mecabDictionaryPath: string | undefined;
+
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (!arg) break;
+
+    if (arg === '--help' || arg === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+    if (arg === '--name') {
+      name = requireValue(args, arg);
+      continue;
+    }
+    if (arg === '--description') {
+      description = requireValue(args, arg);
+      continue;
+    }
+    if (arg === '--issue') {
+      issueRefs.push(requireValue(args, arg));
+      continue;
+    }
+    if (arg === '--known-word') {
+      const value = requireValue(args, arg);
+      const separator = value.indexOf(':');
+      knownWords.push(
+        separator === -1
+          ? value
+          : { text: value.slice(0, separator), reading: value.slice(separator + 1) },
+      );
+      continue;
+    }
+    if (arg === '--jlpt') {
+      const value = requireValue(args, arg);
+      const separator = value.indexOf('=');
+      const level = separator === -1 ? '' : value.slice(separator + 1);
+      if (separator === -1 || !JLPT_LEVELS.has(level)) {
+        throw new Error(`Invalid --jlpt value "${value}"; expected <term>=N1..N5`);
+      }
+      jlptLevels[value.slice(0, separator)] = level as JlptLevel;
+      continue;
+    }
+    if (arg === '--local-frequency') {
+      const value = requireValue(args, arg);
+      const separator = value.indexOf('=');
+      const rank = separator === -1 ? Number.NaN : Number(value.slice(separator + 1));
+      if (!Number.isInteger(rank) || rank <= 0) {
+        throw new Error(`Invalid --local-frequency value "${value}"; expected <term>=<rank>`);
+      }
+      localFrequencyRanks[value.slice(0, separator)] = rank;
+      continue;
+    }
+    if (arg === '--match-mode') {
+      const value = requireValue(args, arg);
+      if (value !== 'headword' && value !== 'surface') {
+        throw new Error(`Invalid --match-mode "${value}"; expected headword|surface`);
+      }
+      config.knownWordMatchMode = value;
+      config.frequencyMatchMode = value;
+      continue;
+    }
+    if (arg === '--min-sentence-words') {
+      const value = Number(requireValue(args, arg));
+      if (!Number.isInteger(value) || value < 0) {
+        throw new Error('Invalid --min-sentence-words value');
+      }
+      config.minSentenceWordsForNPlusOne = value;
+      continue;
+    }
+    if (arg === '--no-known-words') {
+      config.knownWordsEnabled = false;
+      continue;
+    }
+    if (arg === '--no-nplusone') {
+      config.nPlusOneEnabled = false;
+      continue;
+    }
+    if (arg === '--no-jlpt') {
+      config.jlptEnabled = false;
+      continue;
+    }
+    if (arg === '--no-name-match') {
+      config.nameMatchEnabled = false;
+      continue;
+    }
+    if (arg === '--no-frequency') {
+      config.frequencyEnabled = false;
+      continue;
+    }
+    if (arg === '--out-dir') {
+      outDir = requireValue(args, arg);
+      continue;
+    }
+    if (arg === '--force') {
+      force = true;
+      continue;
+    }
+    if (arg === '--yomitan-extension') {
+      yomitanExtensionPath = requireValue(args, arg);
+      continue;
+    }
+    if (arg === '--yomitan-user-data') {
+      yomitanUserDataPath = requireValue(args, arg);
+      continue;
+    }
+    if (arg === '--mecab-command') {
+      mecabCommand = requireValue(args, arg);
+      continue;
+    }
+    if (arg === '--mecab-dictionary') {
+      mecabDictionaryPath = requireValue(args, arg);
+      continue;
+    }
+    if (arg.startsWith('-') && arg !== '-') {
+      throw new Error(`Unknown flag: ${arg}`);
+    }
+    inputParts.push(arg);
+  }
+
+  if (!name || !/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+    throw new Error('A kebab-case --name is required (e.g. --name kureru-lexical-keep)');
+  }
+  const text = inputParts.join(' ').trim();
+  if (!text) {
+    throw new Error('Provide the subtitle text to record as positional arguments.');
+  }
+
+  if (knownWords.length > 0) config.knownWords = knownWords;
+  if (Object.keys(jlptLevels).length > 0) config.jlptLevels = jlptLevels;
+  if (Object.keys(localFrequencyRanks).length > 0) {
+    config.localFrequencyRanks = localFrequencyRanks;
+  }
+
+  return {
+    name,
+    text,
+    description,
+    issueRefs,
+    config,
+    outDir,
+    force,
+    yomitanExtensionPath,
+    yomitanUserDataPath,
+    mecabCommand,
+    mecabDictionaryPath,
+  };
+}
+
+const RECORDER_SHIM_SCRIPT = `
+(() => {
+  const g = globalThis;
+  if (g.__subminerGoldenRecorderInstalled) { return true; }
+  g.__subminerGoldenRecorderInstalled = true;
+  g.__subminerGoldenMessages = [];
+  const runtime = chrome.runtime;
+  const original = runtime.sendMessage.bind(runtime);
+  runtime.sendMessage = (payload, callback) => {
+    return original(payload, (response) => {
+      try {
+        g.__subminerGoldenMessages.push(JSON.parse(JSON.stringify({
+          action: payload && payload.action ? payload.action : '',
+          params: payload && typeof payload.params !== 'undefined' ? payload.params : null,
+          response: typeof response !== 'undefined' ? response : null,
+        })));
+      } catch {}
+      if (callback) { callback(response); }
+    });
+  };
+  return true;
+})();
+`;
+
+const RECORDER_DRAIN_SCRIPT = `
+(() => {
+  const g = globalThis;
+  const log = g.__subminerGoldenMessages || [];
+  g.__subminerGoldenMessages = [];
+  return JSON.stringify(log);
+})();
+`;
+
+interface RecordingSink {
+  messages: GoldenRecordedMessage[];
+  scripts: GoldenRecordedScript[];
+  mecab: Record<string, Token[] | null>;
+}
+
+function patchParserWindowForRecording(
+  window: Electron.BrowserWindow | null,
+  patched: WeakSet<object>,
+  sink: RecordingSink,
+): void {
+  if (!window || window.isDestroyed()) {
+    return;
+  }
+  const webContents = window.webContents as unknown as {
+    executeJavaScript: (script: string, userGesture?: boolean) => Promise<unknown>;
+  };
+  if (patched.has(webContents)) {
+    return;
+  }
+  patched.add(webContents);
+
+  const original = webContents.executeJavaScript.bind(webContents);
+  let shimReady: Promise<unknown> | null = null;
+  const drain = async (): Promise<void> => {
+    try {
+      const raw = (await original(RECORDER_DRAIN_SCRIPT, true)) as string;
+      const drained = JSON.parse(raw) as GoldenRecordedMessage[];
+      sink.messages.push(...drained);
+    } catch (error) {
+      process.stderr.write(
+        `Warning: failed to drain recorded messages: ${(error as Error).message}\n`,
+      );
+    }
+  };
+
+  webContents.executeJavaScript = async (script: string, userGesture?: boolean) => {
+    if (!shimReady) {
+      shimReady = original(RECORDER_SHIM_SCRIPT, true);
+    }
+    try {
+      await shimReady;
+    } catch {
+      shimReady = null;
+    }
+    let result: unknown;
+    try {
+      result = await original(script, userGesture);
+    } finally {
+      await drain();
+    }
+    sink.scripts.push({
+      sha256: hashInjectedScript(script),
+      marker: classifyInjectedScript(script),
+      result: result === undefined ? null : result,
+    });
+    return result;
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parseCliArgs(process.argv.slice(2));
+  const outPath = path.join(options.outDir, `${options.name}.json`);
+  if (fs.existsSync(outPath) && !options.force) {
+    throw new Error(`${outPath} already exists; pass --force to overwrite.`);
+  }
+
+  const electronModule = await import('electron').catch(() => null);
+  if (!electronModule?.app || !electronModule?.session) {
+    throw new Error(
+      'Electron runtime is required; run via `bun run record-tokenizer-fixture:electron`.',
+    );
+  }
+
+  const mecabTokenizer = new MecabTokenizer({
+    mecabCommand: options.mecabCommand,
+    dictionaryPath: options.mecabDictionaryPath,
+  });
+  if (!(await mecabTokenizer.checkAvailability())) {
+    throw new Error('MeCab is not available on this system.');
+  }
+
+  if (typeof electronModule.app.setPath === 'function') {
+    electronModule.app.setPath('userData', options.yomitanUserDataPath);
+  }
+  await electronModule.app.whenReady();
+
+  const extensionPath = resolveBuiltYomitanExtensionPath({
+    explicitPath: options.yomitanExtensionPath,
+    cwd: process.cwd(),
+  });
+  if (!extensionPath) {
+    throw new Error('No built Yomitan extension found; run `bun run build:yomitan` first.');
+  }
+  const extension = await electronModule.session.defaultSession.loadExtension(extensionPath, {
+    allowFileAccess: true,
+  });
+
+  const sink: RecordingSink = { messages: [], scripts: [], mecab: {} };
+  const patched = new WeakSet<object>();
+  let parserWindow: Electron.BrowserWindow | null = null;
+  let parserReadyPromise: Promise<void> | null = null;
+  let parserInitPromise: Promise<boolean> | null = null;
+
+  const lookups = buildFixtureLookups(options.config);
+  const runtimeDeps = createTokenizerDepsRuntime({
+    getYomitanExt: () => extension,
+    getYomitanParserWindow: () => {
+      patchParserWindowForRecording(parserWindow, patched, sink);
+      return parserWindow;
+    },
+    setYomitanParserWindow: (window) => {
+      parserWindow = window;
+      patchParserWindowForRecording(parserWindow, patched, sink);
+    },
+    getYomitanParserReadyPromise: () => parserReadyPromise,
+    setYomitanParserReadyPromise: (promise) => {
+      parserReadyPromise = promise;
+    },
+    getYomitanParserInitPromise: () => parserInitPromise,
+    setYomitanParserInitPromise: (promise) => {
+      parserInitPromise = promise;
+    },
+    isKnownWord: lookups.isKnownWord,
+    getJlptLevel: lookups.getJlptLevel,
+    getFrequencyRank: lookups.getFrequencyRank,
+    ...fixtureConfigGetters(options.config),
+    getMecabTokenizer: () => ({
+      tokenize: async (text: string) => {
+        const rawTokens = await mecabTokenizer.tokenize(text);
+        sink.mecab[text] = rawTokens;
+        return rawTokens;
+      },
+    }),
+  });
+  const deps = {
+    ...runtimeDeps,
+    // Same pinned enrichment implementation the replay harness uses.
+    enrichTokensWithMecab: async (
+      tokens: Parameters<typeof enrichTokensWithMecabPos1>[0],
+      mecabTokens: Parameters<typeof enrichTokensWithMecabPos1>[1],
+    ) => enrichTokensWithMecabPos1(tokens, mecabTokens),
+  };
+
+  try {
+    const subtitleData = await tokenizeSubtitle(options.text, deps);
+    const expectedTokens = projectGoldenTokens(subtitleData.tokens);
+
+    const prunedMessages = pruneGoldenMessages(sink.messages);
+    const fixture: GoldenFixture = {
+      name: options.name,
+      ...(options.description ? { description: options.description } : {}),
+      ...(options.issueRefs.length > 0 ? { issueRefs: options.issueRefs } : {}),
+      recordedAt: new Date().toISOString(),
+      input: { text: options.text },
+      config: options.config,
+      recording: {
+        messages: prunedMessages,
+        scripts: sink.scripts,
+        mecab: sink.mecab,
+      },
+      expected: { tokens: expectedTokens },
+    };
+
+    fs.mkdirSync(options.outDir, { recursive: true });
+    fs.writeFileSync(outPath, `${JSON.stringify(fixture, null, 2)}\n`);
+
+    process.stdout.write(`Recorded ${outPath}\n`);
+    process.stdout.write(
+      `  messages=${prunedMessages.length} scripts=${sink.scripts.length} mecabTexts=${Object.keys(sink.mecab).length}\n`,
+    );
+    process.stdout.write('\nExpected tokens (review before committing):\n');
+    if (!expectedTokens || expectedTokens.length === 0) {
+      process.stdout.write('  (none)\n');
+    } else {
+      for (const token of expectedTokens) {
+        const flags = [
+          token.isKnown ? 'known' : null,
+          token.isNPlusOneTarget ? 'n+1' : null,
+          token.isNameMatch ? 'name' : null,
+          token.isUnparsedRun ? 'unparsed' : null,
+          token.jlptLevel ?? null,
+          token.frequencyRank !== undefined ? `freq=${token.frequencyRank}` : null,
+        ]
+          .filter(Boolean)
+          .join(', ');
+        process.stdout.write(
+          `  ${token.surface} -> ${token.headword} (${token.reading})${flags ? ` [${flags}]` : ''}\n`,
+        );
+      }
+    }
+    process.stdout.write(
+      '\nVerify replay with: bun test src/core/services/tokenizer/golden-corpus.test.ts\n',
+    );
+  } finally {
+    if (parserWindow) {
+      const window = parserWindow as Electron.BrowserWindow;
+      if (!window.isDestroyed()) {
+        window.destroy();
+      }
+    }
+    electronModule.app.quit();
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(`Error: ${(error as Error).message}`);
+    process.exit(1);
+  });

--- a/scripts/yomitan-api-request.test.ts
+++ b/scripts/yomitan-api-request.test.ts
@@ -3,18 +3,51 @@ import test from 'node:test';
 
 import { fetchYomitanApi } from './yomitan-api-request.js';
 
-test('fetchYomitanApi reports a clear timeout when the bridge stalls', async () => {
-  const server = Bun.serve({
+function createStalledServer(): ReturnType<typeof Bun.serve> {
+  return Bun.serve({
     hostname: '127.0.0.1',
     port: 0,
     fetch: () => new Promise<Response>(() => {}),
   });
+}
+
+test('fetchYomitanApi reports a clear timeout when the bridge stalls', async () => {
+  const server = createStalledServer();
 
   try {
     await assert.rejects(
       () => fetchYomitanApi(`${server.url}tokenize`, { method: 'POST' }, 20),
       /Yomitan API request timed out after 20ms/,
     );
+  } finally {
+    server.stop(true);
+  }
+});
+
+test('fetchYomitanApi preserves an init cancellation signal', async () => {
+  const server = createStalledServer();
+  const controller = new AbortController();
+  const reason = new Error('cancelled by caller');
+
+  try {
+    const request = fetchYomitanApi(`${server.url}tokenize`, { signal: controller.signal }, 50);
+    controller.abort(reason);
+    await assert.rejects(request, (error) => error === reason);
+  } finally {
+    server.stop(true);
+  }
+});
+
+test('fetchYomitanApi preserves a Request input cancellation signal', async () => {
+  const server = createStalledServer();
+  const controller = new AbortController();
+  const reason = new Error('cancelled by request');
+  const input = new Request(`${server.url}tokenize`, { signal: controller.signal });
+
+  try {
+    const request = fetchYomitanApi(input, undefined, 50);
+    controller.abort(reason);
+    await assert.rejects(request, (error) => error === reason);
   } finally {
     server.stop(true);
   }

--- a/scripts/yomitan-api-request.test.ts
+++ b/scripts/yomitan-api-request.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { fetchYomitanApi } from './yomitan-api-request.js';
+
+test('fetchYomitanApi reports a clear timeout when the bridge stalls', async () => {
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch: () => new Promise<Response>(() => {}),
+  });
+
+  try {
+    await assert.rejects(
+      () => fetchYomitanApi(`${server.url}tokenize`, { method: 'POST' }, 20),
+      /Yomitan API request timed out after 20ms/,
+    );
+  } finally {
+    server.stop(true);
+  }
+});

--- a/scripts/yomitan-api-request.test.ts
+++ b/scripts/yomitan-api-request.test.ts
@@ -52,3 +52,18 @@ test('fetchYomitanApi preserves a Request input cancellation signal', async () =
     server.stop(true);
   }
 });
+
+test('fetchYomitanApi accepts a null init cancellation signal', async () => {
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch: () => new Response('ok'),
+  });
+
+  try {
+    const response = await fetchYomitanApi(`${server.url}tokenize`, { signal: null }, 50);
+    assert.equal(response.status, 200);
+  } finally {
+    server.stop(true);
+  }
+});

--- a/scripts/yomitan-api-request.ts
+++ b/scripts/yomitan-api-request.ts
@@ -1,0 +1,21 @@
+const DEFAULT_YOMITAN_API_TIMEOUT_MS = 10_000;
+
+export async function fetchYomitanApi(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs = DEFAULT_YOMITAN_API_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`Yomitan API request timed out after ${timeoutMs}ms`, { cause: error });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/scripts/yomitan-api-request.ts
+++ b/scripts/yomitan-api-request.ts
@@ -6,10 +6,15 @@ export async function fetchYomitanApi(
   timeoutMs = DEFAULT_YOMITAN_API_TIMEOUT_MS,
 ): Promise<Response> {
   const controller = new AbortController();
+  const requestSignal = input instanceof Request ? input.signal : undefined;
+  const signals = [controller.signal, init?.signal, requestSignal].filter(
+    (signal): signal is AbortSignal => signal !== undefined,
+  );
+  const signal = signals.length === 1 ? controller.signal : AbortSignal.any(signals);
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    return await fetch(input, { ...init, signal: controller.signal });
+    return await fetch(input, { ...init, signal });
   } catch (error) {
     if (controller.signal.aborted) {
       throw new Error(`Yomitan API request timed out after ${timeoutMs}ms`, { cause: error });

--- a/scripts/yomitan-api-request.ts
+++ b/scripts/yomitan-api-request.ts
@@ -8,7 +8,7 @@ export async function fetchYomitanApi(
   const controller = new AbortController();
   const requestSignal = input instanceof Request ? input.signal : undefined;
   const signals = [controller.signal, init?.signal, requestSignal].filter(
-    (signal): signal is AbortSignal => signal !== undefined,
+    (signal): signal is AbortSignal => signal != null,
   );
   const signal = signals.length === 1 ? controller.signal : AbortSignal.any(signals);
   const timeout = setTimeout(() => controller.abort(), timeoutMs);

--- a/src/anki-integration/known-word-cache.test.ts
+++ b/src/anki-integration/known-word-cache.test.ts
@@ -762,7 +762,10 @@ test('KnownWordCacheManager suppresses reading-only matches when disallowed', as
     // Reading-only match stays available for kana subtitle text…
     assert.equal(manager.isKnownWord('けいこく'), true);
     // …but a kanji token's reading (渓谷/けいこく) must not borrow 警告's.
-    assert.equal(manager.isKnownWord('けいこく', undefined, { allowReadingOnlyMatch: false }), false);
+    assert.equal(
+      manager.isKnownWord('けいこく', undefined, { allowReadingOnlyMatch: false }),
+      false,
+    );
     // Mined word texts still match regardless of the flag.
     assert.equal(manager.isKnownWord('警告', undefined, { allowReadingOnlyMatch: false }), true);
   } finally {

--- a/src/core/services/tokenizer/__fixtures__/golden/README.md
+++ b/src/core/services/tokenizer/__fixtures__/golden/README.md
@@ -1,0 +1,72 @@
+# Tokenizer golden corpus
+
+End-to-end regression fixtures for the tokenizer/annotation pipeline. Each
+`.json` file captures one real subtitle line together with everything the
+pipeline consumed while tokenizing it live:
+
+- `recording.messages` — the raw Yomitan backend responses
+  (`chrome.runtime.sendMessage` level: `optionsGetFull`, `getDictionaryInfo`,
+  `parseText`, `termsFind`, `getTermFrequencies`), pruned to the fields the
+  injected scanning helpers actually read.
+- `recording.scripts` — sha256 → result pairs for each injected script, used
+  only as a replay fallback if a script cannot run in the vm.
+- `recording.mecab` — raw MeCab tokens keyed by the tokenized text.
+- `config` — annotation toggles plus fixture-local known words, JLPT levels,
+  and local frequency ranks (see `golden-corpus-harness.ts` for the simplified
+  known-word semantics shared by recorder and replay).
+- `expected.tokens` — the annotated tokens the full pipeline produced at
+  record time. **This is the assertion.** Review it before committing; it is a
+  characterization of current behavior, not a statement that the behavior is
+  ideal.
+
+`golden-corpus.test.ts` replays every fixture through the real
+`tokenizeSubtitle` (scan-token merge, MeCab enrichment, frequency ranks,
+annotation stage, noise suppression) by executing the real injected scripts in
+a `node:vm` sandbox against the recorded responses — no Electron, no
+dictionaries, no network.
+
+## Recording a fixture
+
+Requires a built Yomitan extension (`bun run build:yomitan`), your SubMiner
+Yomitan profile (`~/.config/SubMiner`), and MeCab:
+
+```sh
+bun run record-tokenizer-fixture:electron -- \
+  --name my-regression-case \
+  --issue "#123" \
+  --description "what behavior this pins down" \
+  --known-word 私 --known-word 要る:いる \
+  --jlpt 美しい=N4 \
+  そのまま字幕の一行
+```
+
+Run with `--help` for all options (annotation toggles, match mode, overwrite
+with `--force`, ...). The recorder prints the expected tokens for review and
+the fixture replays immediately via:
+
+```sh
+bun test src/core/services/tokenizer/golden-corpus.test.ts
+```
+
+## When a fixture fails
+
+A failure means the pipeline now produces different annotated tokens for that
+line. If the change is intentional, re-record the fixture with `--force`
+(same flags — they are stored in the fixture's `config`) and review the diff
+of `expected.tokens`; the diff _is_ the behavior change. If the change is not
+intentional, you found the regression before shipping it.
+
+Fixture dictionaries reflect whatever was installed in the recording profile,
+so re-recorded fixtures may differ in frequency ranks if dictionaries changed.
+
+## Comparing against stock Yomitan
+
+`bun run compare-yomitan-api:electron` diffs SubMiner's tokenization against a
+stock Yomitan instance reached through the
+[yomitan-api](https://github.com/yomidevs/yomitan-api) bridge
+(`http://127.0.0.1:19633`, enable "Yomitan API" in the browser extension's
+settings). Without arguments it compares every fixture text; pass sentences or
+`--file <path>` for ad-hoc checks. It reports segmentation, reading, and
+headword-form divergence and exits non-zero on any difference — useful for
+spot-checking that the pipeline still matches what Yomitan itself would
+produce, with your real browser profile and dictionaries as the reference.

--- a/src/core/services/tokenizer/__fixtures__/golden/compound-verb-merge.json
+++ b/src/core/services/tokenizer/__fixtures__/golden/compound-verb-merge.json
@@ -1,0 +1,6460 @@
+{
+  "name": "compound-verb-merge",
+  "description": "parseText segmentation wins over termsFind fragments for compound verbs",
+  "recordedAt": "2026-07-11T00:48:59.214Z",
+  "input": {
+    "text": "取り組んでいる"
+  },
+  "config": {},
+  "recording": {
+    "messages": [
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "parseText",
+        "params": {
+          "text": "取り組んでいる",
+          "optionsContext": {
+            "index": 0
+          },
+          "scanLength": 21,
+          "useInternalParser": true,
+          "useMecabParser": false
+        },
+        "response": {
+          "result": [
+            {
+              "id": "scan",
+              "source": "scanning-parser",
+              "dictionary": null,
+              "index": 0,
+              "content": [
+                [
+                  {
+                    "text": "取",
+                    "reading": "と",
+                    "headwords": [
+                      [
+                        {
+                          "term": "取り組む",
+                          "reading": "とりくむ",
+                          "sources": [
+                            {
+                              "originalText": "取り組んでいる",
+                              "transformedText": "取り組んでいる",
+                              "deinflectedText": "取り組む",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "text": "り",
+                    "reading": ""
+                  },
+                  {
+                    "text": "組",
+                    "reading": "く"
+                  },
+                  {
+                    "text": "んでいる",
+                    "reading": ""
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "取り組んでいる",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      },
+                      {
+                        "name": "-いる",
+                        "description": "1. Indicates an action continues or progresses to a point in time.\n2. Indicates an action is completed and remains as is.\n3. Indicates a state or condition that can be taken to be the result of undergoing some change.\nUsage: Attach いる to the て-form of verbs. い can be dropped in speech.\nAttach でいる after ない negative form of verbs.\n(Slang) Attach おる to the て-form of verbs. Contracts to とる・でる in speech."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 7,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "取り組む",
+                    "reading": "とりくむ",
+                    "sources": [
+                      {
+                        "originalText": "取り組んでいる",
+                        "transformedText": "取り組んでいる",
+                        "deinflectedText": "取り組む",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6360",
+                    "displayValueParsed": false,
+                    "frequency": 6360,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "87115㋕",
+                    "displayValueParsed": false,
+                    "frequency": 87115,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6198",
+                    "displayValueParsed": false,
+                    "frequency": 6198,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "100289㋕",
+                    "displayValueParsed": false,
+                    "frequency": 100289,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 874,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 97,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "取り組",
+                    "reading": "とりくみ",
+                    "sources": [
+                      {
+                        "originalText": "取り組",
+                        "transformedText": "取り組",
+                        "deinflectedText": "取り組",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "190278㋕",
+                    "displayValueParsed": false,
+                    "frequency": 190278,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "234181",
+                    "displayValueParsed": false,
+                    "frequency": 234181,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "193195",
+                    "displayValueParsed": false,
+                    "frequency": 193195,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "264167㋕",
+                    "displayValueParsed": false,
+                    "frequency": 264167,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "取り",
+                    "reading": "とり",
+                    "sources": [
+                      {
+                        "originalText": "取り",
+                        "transformedText": "取り",
+                        "deinflectedText": "取り",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14882",
+                    "displayValueParsed": false,
+                    "frequency": 14882,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "124247㋕",
+                    "displayValueParsed": false,
+                    "frequency": 124247,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3146",
+                    "displayValueParsed": false,
+                    "frequency": 3146,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "92261㋕",
+                    "displayValueParsed": false,
+                    "frequency": 92261,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6400,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "取り",
+                    "reading": "どり",
+                    "sources": [
+                      {
+                        "originalText": "取り",
+                        "transformedText": "取り",
+                        "deinflectedText": "取り",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "112082",
+                    "displayValueParsed": false,
+                    "frequency": 112082,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "237705㋕",
+                    "displayValueParsed": false,
+                    "frequency": 237705,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 33120,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "取る",
+                    "reading": "とる",
+                    "sources": [
+                      {
+                        "originalText": "取り",
+                        "transformedText": "取り",
+                        "deinflectedText": "取る",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "264",
+                    "displayValueParsed": false,
+                    "frequency": 264,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "431㋕",
+                    "displayValueParsed": false,
+                    "frequency": 431,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236",
+                    "displayValueParsed": false,
+                    "frequency": 236,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "573㋕",
+                    "displayValueParsed": false,
+                    "frequency": 573,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 121,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "取",
+                    "reading": "しゅ",
+                    "sources": [
+                      {
+                        "originalText": "取",
+                        "transformedText": "取",
+                        "deinflectedText": "取",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "130701",
+                    "displayValueParsed": false,
+                    "frequency": 130701,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "取",
+                    "reading": "とり",
+                    "sources": [
+                      {
+                        "originalText": "取",
+                        "transformedText": "取",
+                        "deinflectedText": "取",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11716",
+                    "displayValueParsed": false,
+                    "frequency": 11716,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "124247㋕",
+                    "displayValueParsed": false,
+                    "frequency": 124247,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5696",
+                    "displayValueParsed": false,
+                    "frequency": 5696,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "92261㋕",
+                    "displayValueParsed": false,
+                    "frequency": 92261,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 29580,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "取",
+                    "reading": "どり",
+                    "sources": [
+                      {
+                        "originalText": "取",
+                        "transformedText": "取",
+                        "deinflectedText": "取",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "63901",
+                    "displayValueParsed": false,
+                    "frequency": 63901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "237705㋕",
+                    "displayValueParsed": false,
+                    "frequency": 237705,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 82114,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 7
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "り組んでいる",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "り",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30156㋕",
+                    "displayValueParsed": false,
+                    "frequency": 30156,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 626,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "利",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6473",
+                    "displayValueParsed": false,
+                    "frequency": 6473,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10411",
+                    "displayValueParsed": false,
+                    "frequency": 10411,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 15645,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 152148,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "理",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8718",
+                    "displayValueParsed": false,
+                    "frequency": 8718,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6203",
+                    "displayValueParsed": false,
+                    "frequency": 6203,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6444,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 80970,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "里",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9301",
+                    "displayValueParsed": false,
+                    "frequency": 9301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23938",
+                    "displayValueParsed": false,
+                    "frequency": 23938,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9622,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "吏",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "48918",
+                    "displayValueParsed": false,
+                    "frequency": 48918,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "64138",
+                    "displayValueParsed": false,
+                    "frequency": 64138,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "痢",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "148367",
+                    "displayValueParsed": false,
+                    "frequency": 148367,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "113606",
+                    "displayValueParsed": false,
+                    "frequency": 113606,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 120684,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "裏",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "52801",
+                    "displayValueParsed": false,
+                    "frequency": 52801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "64515",
+                    "displayValueParsed": false,
+                    "frequency": 64515,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 40664,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "離",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "20401",
+                    "displayValueParsed": false,
+                    "frequency": 20401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15639",
+                    "displayValueParsed": false,
+                    "frequency": 15639,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 42779,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 129769,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "裡",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18415",
+                    "displayValueParsed": false,
+                    "frequency": 18415,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "68690",
+                    "displayValueParsed": false,
+                    "frequency": 68690,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 57872,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "厘",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150890,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "釐",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "206619",
+                    "displayValueParsed": false,
+                    "frequency": 206619,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "リ",
+                    "reading": "リ",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "リ",
+                        "deinflectedText": "リ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6101㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6101,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10170,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "Ｒｅ：",
+                    "reading": "リ",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "リ",
+                        "deinflectedText": "リ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "組んでいる",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      },
+                      {
+                        "name": "-いる",
+                        "description": "1. Indicates an action continues or progresses to a point in time.\n2. Indicates an action is completed and remains as is.\n3. Indicates a state or condition that can be taken to be the result of undergoing some change.\nUsage: Attach いる to the て-form of verbs. い can be dropped in speech.\nAttach でいる after ない negative form of verbs.\n(Slang) Attach おる to the て-form of verbs. Contracts to とる・でる in speech."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 5,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "組む",
+                    "reading": "くむ",
+                    "sources": [
+                      {
+                        "originalText": "組んでいる",
+                        "transformedText": "組んでいる",
+                        "deinflectedText": "組む",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1749",
+                    "displayValueParsed": false,
+                    "frequency": 1749,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5073㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5073,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1641",
+                    "displayValueParsed": false,
+                    "frequency": 1641,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8816㋕",
+                    "displayValueParsed": false,
+                    "frequency": 8816,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2218,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "組",
+                    "reading": "くみ",
+                    "sources": [
+                      {
+                        "originalText": "組",
+                        "transformedText": "組",
+                        "deinflectedText": "組",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1921",
+                    "displayValueParsed": false,
+                    "frequency": 1921,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "39881㋕",
+                    "displayValueParsed": false,
+                    "frequency": 39881,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1998",
+                    "displayValueParsed": false,
+                    "frequency": 1998,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "31556㋕",
+                    "displayValueParsed": false,
+                    "frequency": 31556,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2399,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 5
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "んでいる",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "んで",
+                    "reading": "んで",
+                    "sources": [
+                      {
+                        "originalText": "んで",
+                        "transformedText": "んで",
+                        "deinflectedText": "んで",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "883㋕",
+                    "displayValueParsed": false,
+                    "frequency": 883,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3502㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3502,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3550㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3550,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 14702,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ん",
+                    "reading": "ん",
+                    "sources": [
+                      {
+                        "originalText": "ん",
+                        "transformedText": "ん",
+                        "deinflectedText": "ん",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34001㋕",
+                    "displayValueParsed": false,
+                    "frequency": 34001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ン",
+                    "reading": "ン",
+                    "sources": [
+                      {
+                        "originalText": "ん",
+                        "transformedText": "ン",
+                        "deinflectedText": "ン",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8493㋕",
+                    "displayValueParsed": false,
+                    "frequency": 8493,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1528㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1528,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27611,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "でいる",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "出居",
+                    "reading": "でい",
+                    "sources": [
+                      {
+                        "originalText": "でい",
+                        "transformedText": "でい",
+                        "deinflectedText": "でい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 142460,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 199,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "デイ",
+                    "reading": "デイ",
+                    "sources": [
+                      {
+                        "originalText": "でい",
+                        "transformedText": "デイ",
+                        "deinflectedText": "デイ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "52913㋕",
+                    "displayValueParsed": false,
+                    "frequency": 52913,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "105503㋕",
+                    "displayValueParsed": false,
+                    "frequency": 105503,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19868㋕",
+                    "displayValueParsed": false,
+                    "frequency": 19868,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11581,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "で",
+                    "reading": "で",
+                    "sources": [
+                      {
+                        "originalText": "で",
+                        "transformedText": "で",
+                        "deinflectedText": "で",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8㋕",
+                    "displayValueParsed": false,
+                    "frequency": 8,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8㋕",
+                    "displayValueParsed": false,
+                    "frequency": 8,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 12,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "出",
+                    "reading": "で",
+                    "sources": [
+                      {
+                        "originalText": "で",
+                        "transformedText": "で",
+                        "deinflectedText": "で",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5606",
+                    "displayValueParsed": false,
+                    "frequency": 5606,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4377",
+                    "displayValueParsed": false,
+                    "frequency": 4377,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36050㋕",
+                    "displayValueParsed": false,
+                    "frequency": 36050,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10211,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 142606,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "でる",
+                    "reading": "でる",
+                    "sources": [
+                      {
+                        "originalText": "で",
+                        "transformedText": "で",
+                        "deinflectedText": "でる",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1230㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1230,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14301㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4009㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4009,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2026,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "出る",
+                    "reading": "でる",
+                    "sources": [
+                      {
+                        "originalText": "で",
+                        "transformedText": "で",
+                        "deinflectedText": "でる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "74",
+                    "displayValueParsed": false,
+                    "frequency": 74,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1230㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1230,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "85",
+                    "displayValueParsed": false,
+                    "frequency": 85,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4009㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4009,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 99,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ｄｅ",
+                    "reading": "デ",
+                    "sources": [
+                      {
+                        "originalText": "で",
+                        "transformedText": "デ",
+                        "deinflectedText": "デ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "26952㋕",
+                    "displayValueParsed": false,
+                    "frequency": 26952,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "184862",
+                    "displayValueParsed": false,
+                    "frequency": 184862,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "いる",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "いる",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "701㋕",
+                    "displayValueParsed": false,
+                    "frequency": 701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "37㋕",
+                    "displayValueParsed": false,
+                    "frequency": 37,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "入る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7401",
+                    "displayValueParsed": false,
+                    "frequency": 7401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "57360",
+                    "displayValueParsed": false,
+                    "frequency": 57360,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "173912㋕",
+                    "displayValueParsed": false,
+                    "frequency": 173912,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22083,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 75676,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "射る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8836",
+                    "displayValueParsed": false,
+                    "frequency": 8836,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15807",
+                    "displayValueParsed": false,
+                    "frequency": 15807,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 19354,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "炒る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54739",
+                    "displayValueParsed": false,
+                    "frequency": 54739,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "63798",
+                    "displayValueParsed": false,
+                    "frequency": 63798,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 21188,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "要る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "701㋕",
+                    "displayValueParsed": false,
+                    "frequency": 701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3812",
+                    "displayValueParsed": false,
+                    "frequency": 3812,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "983㋕",
+                    "displayValueParsed": false,
+                    "frequency": 983,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2982",
+                    "displayValueParsed": false,
+                    "frequency": 2982,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2980,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鋳る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "60104",
+                    "displayValueParsed": false,
+                    "frequency": 60104,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "83416",
+                    "displayValueParsed": false,
+                    "frequency": 83416,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 84432,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "煎る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "61535",
+                    "displayValueParsed": false,
+                    "frequency": 61535,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65367",
+                    "displayValueParsed": false,
+                    "frequency": 65367,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 64561,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "沃る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "122431",
+                    "displayValueParsed": false,
+                    "frequency": 122431,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "没る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "231790",
+                    "displayValueParsed": false,
+                    "frequency": 231790,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "率る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "100203",
+                    "displayValueParsed": false,
+                    "frequency": 100203,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "癒る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23034",
+                    "displayValueParsed": false,
+                    "frequency": 23034,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "43124",
+                    "displayValueParsed": false,
+                    "frequency": 43124,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 127378,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "将る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "212849",
+                    "displayValueParsed": false,
+                    "frequency": 212849,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3021",
+                    "displayValueParsed": false,
+                    "frequency": 3021,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "37㋕",
+                    "displayValueParsed": false,
+                    "frequency": 37,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2172",
+                    "displayValueParsed": false,
+                    "frequency": 2172,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 92231,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鑄る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "255560",
+                    "displayValueParsed": false,
+                    "frequency": 255560,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "206069",
+                    "displayValueParsed": false,
+                    "frequency": 206069,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "熬る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "300815",
+                    "displayValueParsed": false,
+                    "frequency": 300815,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "い",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亥",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47280",
+                    "displayValueParsed": false,
+                    "frequency": 47280,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "56084",
+                    "displayValueParsed": false,
+                    "frequency": 56084,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46249,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伊",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14364",
+                    "displayValueParsed": false,
+                    "frequency": 14364,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30166",
+                    "displayValueParsed": false,
+                    "frequency": 30166,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "位",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4902",
+                    "displayValueParsed": false,
+                    "frequency": 4902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4817",
+                    "displayValueParsed": false,
+                    "frequency": 4817,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 967,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134715,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15864",
+                    "displayValueParsed": false,
+                    "frequency": 15864,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19720",
+                    "displayValueParsed": false,
+                    "frequency": 19720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5024,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胃",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4320",
+                    "displayValueParsed": false,
+                    "frequency": 4320,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4265",
+                    "displayValueParsed": false,
+                    "frequency": 4265,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4335,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 94,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 92,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伍",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "井",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6111",
+                    "displayValueParsed": false,
+                    "frequency": 6111,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19958",
+                    "displayValueParsed": false,
+                    "frequency": 19958,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18798,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "偉",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "42742",
+                    "displayValueParsed": false,
+                    "frequency": 42742,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40683",
+                    "displayValueParsed": false,
+                    "frequency": 40683,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65831㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62518,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夷",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75303",
+                    "displayValueParsed": false,
+                    "frequency": 75303,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 85253,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "委",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "42381",
+                    "displayValueParsed": false,
+                    "frequency": 42381,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23040,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "威",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27002",
+                    "displayValueParsed": false,
+                    "frequency": 27002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36921",
+                    "displayValueParsed": false,
+                    "frequency": 36921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30452,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126695,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45301",
+                    "displayValueParsed": false,
+                    "frequency": 45301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236493",
+                    "displayValueParsed": false,
+                    "frequency": 236493,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "彙",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "105649",
+                    "displayValueParsed": false,
+                    "frequency": 105649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160667",
+                    "displayValueParsed": false,
+                    "frequency": 160667,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "意",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4338",
+                    "displayValueParsed": false,
+                    "frequency": 4338,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4069",
+                    "displayValueParsed": false,
+                    "frequency": 4069,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5912,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "る",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "る",
+                    "reading": "る",
+                    "sources": [
+                      {
+                        "originalText": "る",
+                        "transformedText": "る",
+                        "deinflectedText": "る",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 120252,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "流",
+                    "reading": "る",
+                    "sources": [
+                      {
+                        "originalText": "る",
+                        "transformedText": "る",
+                        "deinflectedText": "る",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "22731",
+                    "displayValueParsed": false,
+                    "frequency": 22731,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "取り組む",
+              "reading": "とりくんでいる"
+            },
+            {
+              "term": "取り組んでいる",
+              "reading": "とりくんでいる"
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": []
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "取り組む",
+              "reading": null
+            },
+            {
+              "term": "取り組んでいる",
+              "reading": null
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "取り組む",
+              "reading": "とりくむ",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 6360,
+              "displayValue": "6360",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "取り組む",
+              "reading": "とりくむ",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 87115,
+              "displayValue": "87115㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "取り組む",
+              "reading": "とりくむ",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 874,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "取り組む",
+              "reading": "とりくむ",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 6198,
+              "displayValue": "6198",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "取り組む",
+              "reading": "とりくむ",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 100289,
+              "displayValue": "100289㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      }
+    ],
+    "scripts": [
+      {
+        "sha256": "fb64f047eb0494f136bb92311df43c5318873298fe3efad6bfa82e5d531a93e1",
+        "marker": "optionsGetFull",
+        "result": {
+          "profileIndex": 0,
+          "scanLength": 21,
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ],
+          "dictionaryPriorityByName": {
+            "Jitendex.org [2026-03-05]": 0,
+            "日本語文法辞典(全集)": 1,
+            "JPDBv2㋕": 2,
+            "Jiten": 3,
+            "CC100": 4,
+            "実用日本語表現辞典": 5,
+            "NHK": 6,
+            "SubMiner Character Dictionary": 7
+          },
+          "dictionaryFrequencyModeByName": {
+            "JPDBv2㋕": "rank-based",
+            "Jiten": "rank-based"
+          }
+        }
+      },
+      {
+        "sha256": "2b98671f8d1efb76565faee78f91b7ca89f03da64cd8f8281cd360a2e3d61ca4",
+        "marker": "parseText",
+        "result": [
+          {
+            "id": "scan",
+            "source": "scanning-parser",
+            "dictionary": null,
+            "index": 0,
+            "content": [
+              [
+                {
+                  "text": "取",
+                  "reading": "と",
+                  "headwords": [
+                    [
+                      {
+                        "term": "取り組む",
+                        "reading": "とりくむ",
+                        "sources": [
+                          {
+                            "originalText": "取り組んでいる",
+                            "transformedText": "取り組んでいる",
+                            "deinflectedText": "取り組む",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "text": "り",
+                  "reading": ""
+                },
+                {
+                  "text": "組",
+                  "reading": "く"
+                },
+                {
+                  "text": "んでいる",
+                  "reading": ""
+                }
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "3e2c663e4ad2f9b1e9de886df313e460062b3d93405d02e92e0f6b559b3feeeb",
+        "marker": "termsFind",
+        "result": [
+          {
+            "surface": "取り組んでいる",
+            "reading": "とりくんでいる",
+            "headword": "取り組む",
+            "headwordReading": "とりくむ",
+            "startPos": 0,
+            "endPos": 7,
+            "isNameMatch": false,
+            "frequencyRank": 6360,
+            "wordClasses": [
+              "v5"
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "86eafd94f0b6897e0e05b833c09ceece9b96c0a02d4efde0fc7ddf03c4bc8c5c",
+        "marker": "getTermFrequencies",
+        "result": []
+      },
+      {
+        "sha256": "2dceb89268e4a5701b99bcaf442bd0a6588b6703d978935440076167bccfe18e",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "取り組む",
+            "reading": "とりくむ",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 6360,
+            "displayValue": "6360",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "取り組む",
+            "reading": "とりくむ",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 87115,
+            "displayValue": "87115㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "取り組む",
+            "reading": "とりくむ",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 874,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "取り組む",
+            "reading": "とりくむ",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 6198,
+            "displayValue": "6198",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "取り組む",
+            "reading": "とりくむ",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 100289,
+            "displayValue": "100289㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      }
+    ],
+    "mecab": {
+      "取り組んでいる": [
+        {
+          "word": "取り組ん",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "五段・マ行",
+          "inflectionForm": "連用タ接続",
+          "headword": "取り組む",
+          "katakanaReading": "トリクン",
+          "pronunciation": "トリクン"
+        },
+        {
+          "word": "で",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "接続助詞",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "で",
+          "katakanaReading": "デ",
+          "pronunciation": "デ"
+        },
+        {
+          "word": "いる",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "非自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "一段",
+          "inflectionForm": "基本形",
+          "headword": "いる",
+          "katakanaReading": "イル",
+          "pronunciation": "イル"
+        }
+      ]
+    }
+  },
+  "expected": {
+    "tokens": [
+      {
+        "surface": "取り組んでいる",
+        "reading": "とりくんでいる",
+        "headword": "取り組む",
+        "startPos": 0,
+        "endPos": 7,
+        "partOfSpeech": "verb",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "とりくむ",
+        "pos1": "動詞",
+        "pos2": "自立",
+        "pos3": "*",
+        "frequencyRank": 6360
+      }
+    ]
+  }
+}

--- a/src/core/services/tokenizer/__fixtures__/golden/honorific-prefix-noun.json
+++ b/src/core/services/tokenizer/__fixtures__/golden/honorific-prefix-noun.json
@@ -1,0 +1,8384 @@
+{
+  "name": "honorific-prefix-noun",
+  "description": "honorific o-prefix noun keeps frequency annotation",
+  "recordedAt": "2026-07-11T00:50:26.618Z",
+  "input": {
+    "text": "お金がない"
+  },
+  "config": {},
+  "recording": {
+    "messages": [
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "parseText",
+        "params": {
+          "text": "お金がない",
+          "optionsContext": {
+            "index": 0
+          },
+          "scanLength": 21,
+          "useInternalParser": true,
+          "useMecabParser": false
+        },
+        "response": {
+          "result": [
+            {
+              "id": "scan",
+              "source": "scanning-parser",
+              "dictionary": null,
+              "index": 0,
+              "content": [
+                [
+                  {
+                    "text": "お",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "お金",
+                          "reading": "おかね",
+                          "sources": [
+                            {
+                              "originalText": "お金",
+                              "transformedText": "お金",
+                              "deinflectedText": "お金",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "text": "金",
+                    "reading": "かね"
+                  }
+                ],
+                [
+                  {
+                    "text": "がな",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "がな",
+                          "reading": "がな",
+                          "sources": [
+                            {
+                              "originalText": "がな",
+                              "transformedText": "がな",
+                              "deinflectedText": "がな",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "い",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "い",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "亥",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "伊",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "位",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "医",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "胃",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "五",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "５",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "伍",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "井",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "偉",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "夷",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "委",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "威",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "居",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "彙",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "意",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "易",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "汝",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "猪",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "異",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "胆",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "藺",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "衣",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "豬",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "豕",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "緯",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "寝",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "堰",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "５０",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "五十",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "五〇",
+                          "reading": "い",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "い",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "いる",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "射る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "鋳る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "沃る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "率る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "癒る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "将る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "居る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "鑄る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "い",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "イ",
+                          "reading": "イ",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "イ",
+                              "deinflectedText": "イ",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "イ",
+                          "reading": "イ",
+                          "sources": [
+                            {
+                              "originalText": "い",
+                              "transformedText": "イ",
+                              "deinflectedText": "イ",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "お金がない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "お金",
+                    "reading": "おかね",
+                    "sources": [
+                      {
+                        "originalText": "お金",
+                        "transformedText": "お金",
+                        "deinflectedText": "お金",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "939",
+                    "displayValueParsed": false,
+                    "frequency": 939,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "53195㋕",
+                    "displayValueParsed": false,
+                    "frequency": 53195,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "701",
+                    "displayValueParsed": false,
+                    "frequency": 701,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40676㋕",
+                    "displayValueParsed": false,
+                    "frequency": 40676,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1032,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "お",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "59㋕",
+                    "displayValueParsed": false,
+                    "frequency": 59,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47㋕",
+                    "displayValueParsed": false,
+                    "frequency": 47,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 63,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "尾",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4717",
+                    "displayValueParsed": false,
+                    "frequency": 4717,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1445㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1445,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11069",
+                    "displayValueParsed": false,
+                    "frequency": 11069,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16887,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 149853,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "御",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "59㋕",
+                    "displayValueParsed": false,
+                    "frequency": 59,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29201",
+                    "displayValueParsed": false,
+                    "frequency": 29201,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47㋕",
+                    "displayValueParsed": false,
+                    "frequency": 47,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13552",
+                    "displayValueParsed": false,
+                    "frequency": 13552,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 31,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 125478,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "緒",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "33603",
+                    "displayValueParsed": false,
+                    "frequency": 33603,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "83550",
+                    "displayValueParsed": false,
+                    "frequency": 83550,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 148795,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "小",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 141511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "諾",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "雄",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "38601",
+                    "displayValueParsed": false,
+                    "frequency": 38601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 142616,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "男",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "58001",
+                    "displayValueParsed": false,
+                    "frequency": 58001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134174,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夫",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "81802",
+                    "displayValueParsed": false,
+                    "frequency": 81802,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "43628㋕",
+                    "displayValueParsed": false,
+                    "frequency": 43628,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "61777",
+                    "displayValueParsed": false,
+                    "frequency": 61777,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -3,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "牡",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "140101",
+                    "displayValueParsed": false,
+                    "frequency": 140101,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "麻",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 140227,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "苧",
+                    "reading": "お",
+                    "sources": [
+                      {
+                        "originalText": "お",
+                        "transformedText": "お",
+                        "deinflectedText": "お",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "135637",
+                    "displayValueParsed": false,
+                    "frequency": 135637,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "金がない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "金がない",
+                    "reading": "かねがない",
+                    "sources": [
+                      {
+                        "originalText": "金がない",
+                        "transformedText": "金がない",
+                        "deinflectedText": "金がない",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "19877",
+                    "displayValueParsed": false,
+                    "frequency": 19877,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "239872㋕",
+                    "displayValueParsed": false,
+                    "frequency": 239872,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10292",
+                    "displayValueParsed": false,
+                    "frequency": 10292,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "75060㋕",
+                    "displayValueParsed": false,
+                    "frequency": 75060,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "金",
+                    "reading": "かね",
+                    "sources": [
+                      {
+                        "originalText": "金",
+                        "transformedText": "金",
+                        "deinflectedText": "金",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "797",
+                    "displayValueParsed": false,
+                    "frequency": 797,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "61001㋕",
+                    "displayValueParsed": false,
+                    "frequency": 61001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "770",
+                    "displayValueParsed": false,
+                    "frequency": 770,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1964,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 57007,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "金",
+                    "reading": "きん",
+                    "sources": [
+                      {
+                        "originalText": "金",
+                        "transformedText": "金",
+                        "deinflectedText": "金",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2002",
+                    "displayValueParsed": false,
+                    "frequency": 2002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22789㋕",
+                    "displayValueParsed": false,
+                    "frequency": 22789,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1737",
+                    "displayValueParsed": false,
+                    "frequency": 1737,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "7998㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7998,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 804,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 57007,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "金",
+                    "reading": "こがね",
+                    "sources": [
+                      {
+                        "originalText": "金",
+                        "transformedText": "金",
+                        "deinflectedText": "金",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "52232㋕",
+                    "displayValueParsed": false,
+                    "frequency": 52232,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "257301",
+                    "displayValueParsed": false,
+                    "frequency": 257301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 57007,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "金",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "金",
+                        "transformedText": "金",
+                        "deinflectedText": "金",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "69180",
+                    "displayValueParsed": false,
+                    "frequency": 69180,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 57007,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 4
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "がない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "がな",
+                    "reading": "がな",
+                    "sources": [
+                      {
+                        "originalText": "がな",
+                        "transformedText": "がな",
+                        "deinflectedText": "がな",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1841㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1841,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5511㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5511,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 40356,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "が",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 98,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "画",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17740㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17740,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6857,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 99577,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "我",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "43401",
+                    "displayValueParsed": false,
+                    "frequency": 43401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "22574",
+                    "displayValueParsed": false,
+                    "frequency": 22574,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 56290,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 136539,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "蛾",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23270",
+                    "displayValueParsed": false,
+                    "frequency": 23270,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "29260",
+                    "displayValueParsed": false,
+                    "frequency": 29260,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22399,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "賀",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15246",
+                    "displayValueParsed": false,
+                    "frequency": 15246,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40227",
+                    "displayValueParsed": false,
+                    "frequency": 40227,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 47197,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "雅",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "43501",
+                    "displayValueParsed": false,
+                    "frequency": 43501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "153419",
+                    "displayValueParsed": false,
+                    "frequency": 153419,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "264167㋕",
+                    "displayValueParsed": false,
+                    "frequency": 264167,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 90509,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 144159,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "駕",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "33231",
+                    "displayValueParsed": false,
+                    "frequency": 33231,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "80386",
+                    "displayValueParsed": false,
+                    "frequency": 80386,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 95947,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ガ",
+                    "reading": "ガ",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "ガ",
+                        "deinflectedText": "ガ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "16378㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16378,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18294㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18294,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "135016㋕",
+                    "displayValueParsed": false,
+                    "frequency": 135016,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14208㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14208,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 37336,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ない",
+                    "reading": "ない",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "ない",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29㋕",
+                    "displayValueParsed": false,
+                    "frequency": 29,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "180101㋕",
+                    "displayValueParsed": false,
+                    "frequency": 180101,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "31㋕",
+                    "displayValueParsed": false,
+                    "frequency": 31,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 17,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "無い",
+                    "reading": "ない",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "ない",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29㋕",
+                    "displayValueParsed": false,
+                    "frequency": 29,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1442",
+                    "displayValueParsed": false,
+                    "frequency": 1442,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "31㋕",
+                    "displayValueParsed": false,
+                    "frequency": 31,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2317",
+                    "displayValueParsed": false,
+                    "frequency": 2317,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 28,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "内",
+                    "reading": "ない",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "ない",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "781",
+                    "displayValueParsed": false,
+                    "frequency": 781,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "180101㋕",
+                    "displayValueParsed": false,
+                    "frequency": 180101,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1401",
+                    "displayValueParsed": false,
+                    "frequency": 1401,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "7119㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7119,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 357,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 149564,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亡い",
+                    "reading": "ない",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "ない",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "30737",
+                    "displayValueParsed": false,
+                    "frequency": 30737,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47880",
+                    "displayValueParsed": false,
+                    "frequency": 47880,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 79471,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "地震",
+                    "reading": "ない",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "ない",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 61837,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "なう",
+                    "reading": "なう",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "なう",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45193㋕",
+                    "displayValueParsed": false,
+                    "frequency": 45193,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "51888㋕",
+                    "displayValueParsed": false,
+                    "frequency": 51888,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54078㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54078,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "55371㋕",
+                    "displayValueParsed": false,
+                    "frequency": 55371,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 51840,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "綯う",
+                    "reading": "なう",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "なう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54078㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54078,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "103761",
+                    "displayValueParsed": false,
+                    "frequency": 103761,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "53554㋕",
+                    "displayValueParsed": false,
+                    "frequency": 53554,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "124609",
+                    "displayValueParsed": false,
+                    "frequency": 124609,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 43653,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "な",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "26㋕",
+                    "displayValueParsed": false,
+                    "frequency": 26,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 89,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "名",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "664",
+                    "displayValueParsed": false,
+                    "frequency": 664,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "835",
+                    "displayValueParsed": false,
+                    "frequency": 835,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14368㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14368,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1813,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 137968,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "菜",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18106",
+                    "displayValueParsed": false,
+                    "frequency": 18106,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21850",
+                    "displayValueParsed": false,
+                    "frequency": 21850,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22974,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 143251,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "儺",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "84943",
+                    "displayValueParsed": false,
+                    "frequency": 84943,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "108965",
+                    "displayValueParsed": false,
+                    "frequency": 108965,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 130367,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "己",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "汝",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8445",
+                    "displayValueParsed": false,
+                    "frequency": 8445,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "dictionary",
+                    "inflectionRules": [
+                      {
+                        "name": "redirected from な"
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "七",
+                    "reading": "しち",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "七",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3638",
+                    "displayValueParsed": false,
+                    "frequency": 3638,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23782㋕",
+                    "displayValueParsed": false,
+                    "frequency": 23782,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11209,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "dictionary",
+                    "inflectionRules": [
+                      {
+                        "name": "redirected from な"
+                      }
+                    ]
+                  }
+                ],
+                "score": 197,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "七",
+                    "reading": "なな",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "七",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1477",
+                    "displayValueParsed": false,
+                    "frequency": 1477,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "13298㋕",
+                    "displayValueParsed": false,
+                    "frequency": 13298,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4003㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4003,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4828,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "dictionary",
+                    "inflectionRules": [
+                      {
+                        "name": "redirected from な"
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "七",
+                    "reading": "チー",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "七",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "い",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "い",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亥",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47280",
+                    "displayValueParsed": false,
+                    "frequency": 47280,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "56084",
+                    "displayValueParsed": false,
+                    "frequency": 56084,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46249,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伊",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14364",
+                    "displayValueParsed": false,
+                    "frequency": 14364,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30166",
+                    "displayValueParsed": false,
+                    "frequency": 30166,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "位",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4902",
+                    "displayValueParsed": false,
+                    "frequency": 4902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4817",
+                    "displayValueParsed": false,
+                    "frequency": 4817,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 967,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134715,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15864",
+                    "displayValueParsed": false,
+                    "frequency": 15864,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19720",
+                    "displayValueParsed": false,
+                    "frequency": 19720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5024,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胃",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4320",
+                    "displayValueParsed": false,
+                    "frequency": 4320,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4265",
+                    "displayValueParsed": false,
+                    "frequency": 4265,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4335,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 94,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 92,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伍",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "井",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6111",
+                    "displayValueParsed": false,
+                    "frequency": 6111,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19958",
+                    "displayValueParsed": false,
+                    "frequency": 19958,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18798,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "偉",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "42742",
+                    "displayValueParsed": false,
+                    "frequency": 42742,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40683",
+                    "displayValueParsed": false,
+                    "frequency": 40683,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65831㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62518,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夷",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75303",
+                    "displayValueParsed": false,
+                    "frequency": 75303,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 85253,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "委",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "42381",
+                    "displayValueParsed": false,
+                    "frequency": 42381,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23040,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "威",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27002",
+                    "displayValueParsed": false,
+                    "frequency": 27002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36921",
+                    "displayValueParsed": false,
+                    "frequency": 36921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30452,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126695,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45301",
+                    "displayValueParsed": false,
+                    "frequency": 45301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236493",
+                    "displayValueParsed": false,
+                    "frequency": 236493,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "彙",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "105649",
+                    "displayValueParsed": false,
+                    "frequency": 105649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160667",
+                    "displayValueParsed": false,
+                    "frequency": 160667,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "意",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4338",
+                    "displayValueParsed": false,
+                    "frequency": 4338,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4069",
+                    "displayValueParsed": false,
+                    "frequency": 4069,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5912,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "易",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 138689,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "汝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "猪",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "118901",
+                    "displayValueParsed": false,
+                    "frequency": 118901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "異",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14852",
+                    "displayValueParsed": false,
+                    "frequency": 14852,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15812",
+                    "displayValueParsed": false,
+                    "frequency": 15812,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4892,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胆",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145167,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "藺",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "94214",
+                    "displayValueParsed": false,
+                    "frequency": 94214,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "138991",
+                    "displayValueParsed": false,
+                    "frequency": 138991,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 99348,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "衣",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24121,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132574,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豬",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "200568",
+                    "displayValueParsed": false,
+                    "frequency": 200568,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "196521",
+                    "displayValueParsed": false,
+                    "frequency": 196521,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豕",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -6,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "緯",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 96278,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "寝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "堰",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -106,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５０",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -107,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五十",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -108,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五〇",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 121488,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "お金",
+              "reading": "おかね"
+            },
+            {
+              "term": "がな",
+              "reading": "がな"
+            },
+            {
+              "term": "い",
+              "reading": "い"
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "お金",
+              "reading": "おかね",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 939,
+              "displayValue": "939",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "お金",
+              "reading": "おかね",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 53195,
+              "displayValue": "53195㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "お金",
+              "reading": "おかね",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 1032,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "お金",
+              "reading": "おかね",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 701,
+              "displayValue": "701",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "お金",
+              "reading": "おかね",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 40676,
+              "displayValue": "40676㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "がな",
+              "reading": "がな",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 1841,
+              "displayValue": "1841㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "がな",
+              "reading": "がな",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 40356,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "がな",
+              "reading": "がな",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 5511,
+              "displayValue": "5511㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "い",
+              "reading": "い",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 2803,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "い",
+              "reading": "い",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 16129,
+              "displayValue": "16129㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      }
+    ],
+    "scripts": [
+      {
+        "sha256": "fb64f047eb0494f136bb92311df43c5318873298fe3efad6bfa82e5d531a93e1",
+        "marker": "optionsGetFull",
+        "result": {
+          "profileIndex": 0,
+          "scanLength": 21,
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ],
+          "dictionaryPriorityByName": {
+            "Jitendex.org [2026-03-05]": 0,
+            "日本語文法辞典(全集)": 1,
+            "JPDBv2㋕": 2,
+            "Jiten": 3,
+            "CC100": 4,
+            "実用日本語表現辞典": 5,
+            "NHK": 6,
+            "SubMiner Character Dictionary": 7
+          },
+          "dictionaryFrequencyModeByName": {
+            "JPDBv2㋕": "rank-based",
+            "Jiten": "rank-based"
+          }
+        }
+      },
+      {
+        "sha256": "0401f4f750489d155573ab97326146d1d91ea64449656d34d2ab03af78e792ec",
+        "marker": "parseText",
+        "result": [
+          {
+            "id": "scan",
+            "source": "scanning-parser",
+            "dictionary": null,
+            "index": 0,
+            "content": [
+              [
+                {
+                  "text": "お",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "お金",
+                        "reading": "おかね",
+                        "sources": [
+                          {
+                            "originalText": "お金",
+                            "transformedText": "お金",
+                            "deinflectedText": "お金",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "text": "金",
+                  "reading": "かね"
+                }
+              ],
+              [
+                {
+                  "text": "がな",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "がな",
+                        "reading": "がな",
+                        "sources": [
+                          {
+                            "originalText": "がな",
+                            "transformedText": "がな",
+                            "deinflectedText": "がな",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "い",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "い",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "亥",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "伊",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "位",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "医",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "胃",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "五",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "５",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "伍",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "井",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "偉",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "夷",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "委",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "威",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "居",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "彙",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "意",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "易",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "汝",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "猪",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "異",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "胆",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "藺",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "衣",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "豬",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "豕",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "緯",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "寝",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "堰",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "５０",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "五十",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "五〇",
+                        "reading": "い",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "い",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "いる",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "射る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "鋳る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "沃る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "率る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "癒る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "将る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "居る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "鑄る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "い",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "イ",
+                        "reading": "イ",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "イ",
+                            "deinflectedText": "イ",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "イ",
+                        "reading": "イ",
+                        "sources": [
+                          {
+                            "originalText": "い",
+                            "transformedText": "イ",
+                            "deinflectedText": "イ",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "c086a7bb8918baa18169269c2fe53dc3c0ac143ef4571ab0d996e257936e2d56",
+        "marker": "termsFind",
+        "result": [
+          {
+            "surface": "お金",
+            "reading": "おかね",
+            "headword": "お金",
+            "headwordReading": "おかね",
+            "startPos": 0,
+            "endPos": 2,
+            "isNameMatch": false,
+            "frequencyRank": 939
+          },
+          {
+            "surface": "がな",
+            "reading": "がな",
+            "headword": "がな",
+            "headwordReading": "がな",
+            "startPos": 2,
+            "endPos": 4,
+            "isNameMatch": false,
+            "frequencyRank": 1841
+          },
+          {
+            "surface": "い",
+            "reading": "い",
+            "headword": "い",
+            "headwordReading": "い",
+            "startPos": 4,
+            "endPos": 5,
+            "isNameMatch": false,
+            "frequencyRank": 16129
+          }
+        ]
+      },
+      {
+        "sha256": "7979fe033663b33205af5ebf0af6e87256d33651e4f13031ca15cdaea31437e0",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "お金",
+            "reading": "おかね",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 939,
+            "displayValue": "939",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "お金",
+            "reading": "おかね",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 53195,
+            "displayValue": "53195㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "お金",
+            "reading": "おかね",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 1032,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "お金",
+            "reading": "おかね",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 701,
+            "displayValue": "701",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "お金",
+            "reading": "おかね",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 40676,
+            "displayValue": "40676㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "がな",
+            "reading": "がな",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 1841,
+            "displayValue": "1841㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "がな",
+            "reading": "がな",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 40356,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "がな",
+            "reading": "がな",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 5511,
+            "displayValue": "5511㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "い",
+            "reading": "い",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 2803,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "い",
+            "reading": "い",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 16129,
+            "displayValue": "16129㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      }
+    ],
+    "mecab": {
+      "お金がない": [
+        {
+          "word": "お金",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "一般",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "お金",
+          "katakanaReading": "オカネ",
+          "pronunciation": "オカネ"
+        },
+        {
+          "word": "が",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "格助詞",
+          "pos3": "一般",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "が",
+          "katakanaReading": "ガ",
+          "pronunciation": "ガ"
+        },
+        {
+          "word": "ない",
+          "partOfSpeech": "i_adjective",
+          "pos1": "形容詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "形容詞・アウオ段",
+          "inflectionForm": "基本形",
+          "headword": "ない",
+          "katakanaReading": "ナイ",
+          "pronunciation": "ナイ"
+        }
+      ]
+    }
+  },
+  "expected": {
+    "tokens": [
+      {
+        "surface": "お金",
+        "reading": "おかね",
+        "headword": "お金",
+        "startPos": 0,
+        "endPos": 2,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "おかね",
+        "pos1": "名詞",
+        "pos2": "一般",
+        "pos3": "*",
+        "frequencyRank": 939
+      },
+      {
+        "surface": "がな",
+        "reading": "がな",
+        "headword": "がな",
+        "startPos": 2,
+        "endPos": 4,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "がな",
+        "pos1": "助詞|形容詞",
+        "pos2": "格助詞|自立",
+        "pos3": "一般|*",
+        "frequencyRank": 1841
+      },
+      {
+        "surface": "い",
+        "reading": "い",
+        "headword": "い",
+        "startPos": 4,
+        "endPos": 5,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "い",
+        "pos1": "形容詞",
+        "pos2": "自立",
+        "pos3": "*"
+      }
+    ]
+  }
+}

--- a/src/core/services/tokenizer/__fixtures__/golden/jlpt-levels.json
+++ b/src/core/services/tokenizer/__fixtures__/golden/jlpt-levels.json
@@ -1,0 +1,10278 @@
+{
+  "name": "jlpt-levels",
+  "description": "JLPT levels annotate content words via local lookup",
+  "recordedAt": "2026-07-11T00:50:23.168Z",
+  "input": {
+    "text": "美しい花が咲いた"
+  },
+  "config": {
+    "jlptLevels": {
+      "美しい": "N4",
+      "花": "N5",
+      "咲く": "N3"
+    }
+  },
+  "recording": {
+    "messages": [
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "parseText",
+        "params": {
+          "text": "美しい花が咲いた",
+          "optionsContext": {
+            "index": 0
+          },
+          "scanLength": 21,
+          "useInternalParser": true,
+          "useMecabParser": false
+        },
+        "response": {
+          "result": [
+            {
+              "id": "scan",
+              "source": "scanning-parser",
+              "dictionary": null,
+              "index": 0,
+              "content": [
+                [
+                  {
+                    "text": "美",
+                    "reading": "うつく",
+                    "headwords": [
+                      [
+                        {
+                          "term": "美しい",
+                          "reading": "うつくしい",
+                          "sources": [
+                            {
+                              "originalText": "美しい",
+                              "transformedText": "美しい",
+                              "deinflectedText": "美しい",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "text": "しい",
+                    "reading": ""
+                  }
+                ],
+                [
+                  {
+                    "text": "花",
+                    "reading": "はな",
+                    "headwords": [
+                      [
+                        {
+                          "term": "花が咲く",
+                          "reading": "はながさく",
+                          "sources": [
+                            {
+                              "originalText": "花が咲いた",
+                              "transformedText": "花が咲いた",
+                              "deinflectedText": "花が咲く",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "text": "が",
+                    "reading": ""
+                  },
+                  {
+                    "text": "咲",
+                    "reading": "さ"
+                  },
+                  {
+                    "text": "いた",
+                    "reading": ""
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "美しい花が咲いた",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "美しい",
+                    "reading": "うつくしい",
+                    "sources": [
+                      {
+                        "originalText": "美しい",
+                        "transformedText": "美しい",
+                        "deinflectedText": "美しい",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "674",
+                    "displayValueParsed": false,
+                    "frequency": 674,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "30786㋕",
+                    "displayValueParsed": false,
+                    "frequency": 30786,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "960",
+                    "displayValueParsed": false,
+                    "frequency": 960,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "46183㋕",
+                    "displayValueParsed": false,
+                    "frequency": 46183,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 859,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 106954,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "美",
+                    "reading": "び",
+                    "sources": [
+                      {
+                        "originalText": "美",
+                        "transformedText": "美",
+                        "deinflectedText": "美",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3409",
+                    "displayValueParsed": false,
+                    "frequency": 3409,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2372㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2372,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4548",
+                    "displayValueParsed": false,
+                    "frequency": 4548,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4230,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "美",
+                    "reading": "み",
+                    "sources": [
+                      {
+                        "originalText": "美",
+                        "transformedText": "美",
+                        "deinflectedText": "美",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "25801",
+                    "displayValueParsed": false,
+                    "frequency": 25801,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "しい花が咲いた",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "しい",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "77224㋕",
+                    "displayValueParsed": false,
+                    "frequency": 77224,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12010㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12010,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 32923,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四位",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34969",
+                    "displayValueParsed": false,
+                    "frequency": 34969,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "46869",
+                    "displayValueParsed": false,
+                    "frequency": 46869,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 61397,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四囲",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "53302",
+                    "displayValueParsed": false,
+                    "frequency": 53302,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "77224㋕",
+                    "displayValueParsed": false,
+                    "frequency": 77224,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "84976",
+                    "displayValueParsed": false,
+                    "frequency": 84976,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 105255,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四夷",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "207473",
+                    "displayValueParsed": false,
+                    "frequency": 207473,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "245837",
+                    "displayValueParsed": false,
+                    "frequency": 245837,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 129290,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四維",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "234112",
+                    "displayValueParsed": false,
+                    "frequency": 234112,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "300815",
+                    "displayValueParsed": false,
+                    "frequency": 300815,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 135793,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "尸位",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "思惟",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "37326",
+                    "displayValueParsed": false,
+                    "frequency": 37326,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "70352",
+                    "displayValueParsed": false,
+                    "frequency": 70352,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 48863,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "恣意",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "81551",
+                    "displayValueParsed": false,
+                    "frequency": 81551,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "97944",
+                    "displayValueParsed": false,
+                    "frequency": 97944,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 38003,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "施為",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "245204",
+                    "displayValueParsed": false,
+                    "frequency": 245204,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "旨意",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "206422",
+                    "displayValueParsed": false,
+                    "frequency": 206422,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "215165",
+                    "displayValueParsed": false,
+                    "frequency": 215165,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 82915,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私意",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "152144",
+                    "displayValueParsed": false,
+                    "frequency": 152144,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "141217",
+                    "displayValueParsed": false,
+                    "frequency": 141217,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 114175,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "肢位",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "詩意",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "280135",
+                    "displayValueParsed": false,
+                    "frequency": 280135,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "286883",
+                    "displayValueParsed": false,
+                    "frequency": 286883,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 140831,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "椎",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "37416",
+                    "displayValueParsed": false,
+                    "frequency": 37416,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "48565",
+                    "displayValueParsed": false,
+                    "frequency": 48565,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 45621,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "示威",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23200㋕",
+                    "displayValueParsed": false,
+                    "frequency": 23200,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "紫衣",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 100705,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "緇衣",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "肆意",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "242901",
+                    "displayValueParsed": false,
+                    "frequency": 242901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -105,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "尿",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12010㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12010,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "強いる",
+                    "reading": "しいる",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しいる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5629",
+                    "displayValueParsed": false,
+                    "frequency": 5629,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6600㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6600,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4692",
+                    "displayValueParsed": false,
+                    "frequency": 4692,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "18176㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18176,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6742,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "誣いる",
+                    "reading": "しいる",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しいる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "124077㋕",
+                    "displayValueParsed": false,
+                    "frequency": 124077,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "219204",
+                    "displayValueParsed": false,
+                    "frequency": 219204,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "213904",
+                    "displayValueParsed": false,
+                    "frequency": 213904,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158616,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "シイ",
+                    "reading": "シイ",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "シイ",
+                        "deinflectedText": "シイ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "189107㋕",
+                    "displayValueParsed": false,
+                    "frequency": 189107,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "105634㋕",
+                    "displayValueParsed": false,
+                    "frequency": 105634,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "し",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "58㋕",
+                    "displayValueParsed": false,
+                    "frequency": 58,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40㋕",
+                    "displayValueParsed": false,
+                    "frequency": 40,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 107,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "史",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10409",
+                    "displayValueParsed": false,
+                    "frequency": 10409,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14354",
+                    "displayValueParsed": false,
+                    "frequency": 14354,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5055,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 148554,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2539",
+                    "displayValueParsed": false,
+                    "frequency": 2539,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10427㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10427,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11632,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "市",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2466",
+                    "displayValueParsed": false,
+                    "frequency": 2466,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5353",
+                    "displayValueParsed": false,
+                    "frequency": 5353,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36419㋕",
+                    "displayValueParsed": false,
+                    "frequency": 36419,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1754,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "死",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "909",
+                    "displayValueParsed": false,
+                    "frequency": 909,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1050",
+                    "displayValueParsed": false,
+                    "frequency": 1050,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2640,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "氏",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2076",
+                    "displayValueParsed": false,
+                    "frequency": 2076,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3723",
+                    "displayValueParsed": false,
+                    "frequency": 3723,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "128121㋕",
+                    "displayValueParsed": false,
+                    "frequency": 128121,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 754,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "詩",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6043",
+                    "displayValueParsed": false,
+                    "frequency": 6043,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10033",
+                    "displayValueParsed": false,
+                    "frequency": 10033,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5328,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "誌",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14324",
+                    "displayValueParsed": false,
+                    "frequency": 14324,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13547",
+                    "displayValueParsed": false,
+                    "frequency": 13547,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "137640㋕",
+                    "displayValueParsed": false,
+                    "frequency": 137640,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4850,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "４",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10427㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10427,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "264167",
+                    "displayValueParsed": false,
+                    "frequency": 264167,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "巳",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "い花が咲いた",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "い",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亥",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47280",
+                    "displayValueParsed": false,
+                    "frequency": 47280,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "56084",
+                    "displayValueParsed": false,
+                    "frequency": 56084,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46249,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伊",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14364",
+                    "displayValueParsed": false,
+                    "frequency": 14364,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30166",
+                    "displayValueParsed": false,
+                    "frequency": 30166,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "位",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4902",
+                    "displayValueParsed": false,
+                    "frequency": 4902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4817",
+                    "displayValueParsed": false,
+                    "frequency": 4817,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 967,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134715,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15864",
+                    "displayValueParsed": false,
+                    "frequency": 15864,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19720",
+                    "displayValueParsed": false,
+                    "frequency": 19720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5024,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胃",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4320",
+                    "displayValueParsed": false,
+                    "frequency": 4320,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4265",
+                    "displayValueParsed": false,
+                    "frequency": 4265,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4335,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 94,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 92,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伍",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "井",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6111",
+                    "displayValueParsed": false,
+                    "frequency": 6111,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19958",
+                    "displayValueParsed": false,
+                    "frequency": 19958,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18798,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "偉",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "42742",
+                    "displayValueParsed": false,
+                    "frequency": 42742,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40683",
+                    "displayValueParsed": false,
+                    "frequency": 40683,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65831㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62518,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夷",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75303",
+                    "displayValueParsed": false,
+                    "frequency": 75303,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 85253,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "委",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "42381",
+                    "displayValueParsed": false,
+                    "frequency": 42381,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23040,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "威",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27002",
+                    "displayValueParsed": false,
+                    "frequency": 27002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36921",
+                    "displayValueParsed": false,
+                    "frequency": 36921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30452,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126695,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45301",
+                    "displayValueParsed": false,
+                    "frequency": 45301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236493",
+                    "displayValueParsed": false,
+                    "frequency": 236493,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "彙",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "105649",
+                    "displayValueParsed": false,
+                    "frequency": 105649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160667",
+                    "displayValueParsed": false,
+                    "frequency": 160667,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "意",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4338",
+                    "displayValueParsed": false,
+                    "frequency": 4338,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4069",
+                    "displayValueParsed": false,
+                    "frequency": 4069,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5912,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "易",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 138689,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "汝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "猪",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "118901",
+                    "displayValueParsed": false,
+                    "frequency": 118901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "異",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14852",
+                    "displayValueParsed": false,
+                    "frequency": 14852,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15812",
+                    "displayValueParsed": false,
+                    "frequency": 15812,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4892,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胆",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145167,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "藺",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "94214",
+                    "displayValueParsed": false,
+                    "frequency": 94214,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "138991",
+                    "displayValueParsed": false,
+                    "frequency": 138991,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 99348,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "衣",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24121,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132574,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豬",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "200568",
+                    "displayValueParsed": false,
+                    "frequency": 200568,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "196521",
+                    "displayValueParsed": false,
+                    "frequency": 196521,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豕",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -6,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "緯",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 96278,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "寝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "堰",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -106,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５０",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -107,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五十",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -108,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五〇",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 121488,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "花が咲いた",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 5,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "花が咲く",
+                    "reading": "はながさく",
+                    "sources": [
+                      {
+                        "originalText": "花が咲いた",
+                        "transformedText": "花が咲いた",
+                        "deinflectedText": "花が咲く",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7166",
+                    "displayValueParsed": false,
+                    "frequency": 7166,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "196908㋕",
+                    "displayValueParsed": false,
+                    "frequency": 196908,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8761",
+                    "displayValueParsed": false,
+                    "frequency": 8761,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "133002㋕",
+                    "displayValueParsed": false,
+                    "frequency": 133002,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "花",
+                    "reading": "はな",
+                    "sources": [
+                      {
+                        "originalText": "花",
+                        "transformedText": "花",
+                        "deinflectedText": "花",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "755",
+                    "displayValueParsed": false,
+                    "frequency": 755,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7488㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7488,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1011",
+                    "displayValueParsed": false,
+                    "frequency": 1011,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3170㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3170,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 822,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 133030,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 5
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "が咲いた",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "が",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 98,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "画",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17740㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17740,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6857,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 99577,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "我",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "43401",
+                    "displayValueParsed": false,
+                    "frequency": 43401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "22574",
+                    "displayValueParsed": false,
+                    "frequency": 22574,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 56290,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 136539,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "蛾",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23270",
+                    "displayValueParsed": false,
+                    "frequency": 23270,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "29260",
+                    "displayValueParsed": false,
+                    "frequency": 29260,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22399,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "賀",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15246",
+                    "displayValueParsed": false,
+                    "frequency": 15246,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40227",
+                    "displayValueParsed": false,
+                    "frequency": 40227,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 47197,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "雅",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "43501",
+                    "displayValueParsed": false,
+                    "frequency": 43501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "153419",
+                    "displayValueParsed": false,
+                    "frequency": 153419,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "264167㋕",
+                    "displayValueParsed": false,
+                    "frequency": 264167,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 90509,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 144159,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "駕",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "33231",
+                    "displayValueParsed": false,
+                    "frequency": 33231,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "80386",
+                    "displayValueParsed": false,
+                    "frequency": 80386,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 95947,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ガ",
+                    "reading": "ガ",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "ガ",
+                        "deinflectedText": "ガ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "16378㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16378,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18294㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18294,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "135016㋕",
+                    "displayValueParsed": false,
+                    "frequency": 135016,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14208㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14208,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 37336,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "咲いた",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "咲く",
+                    "reading": "さく",
+                    "sources": [
+                      {
+                        "originalText": "咲いた",
+                        "transformedText": "咲いた",
+                        "deinflectedText": "咲く",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3776",
+                    "displayValueParsed": false,
+                    "frequency": 3776,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "96001㋕",
+                    "displayValueParsed": false,
+                    "frequency": 96001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4064",
+                    "displayValueParsed": false,
+                    "frequency": 4064,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2289,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "咲い",
+                    "reading": "咲い",
+                    "sources": [
+                      {
+                        "originalText": "咲い",
+                        "transformedText": "咲い",
+                        "deinflectedText": "咲い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "dictionary",
+                    "inflectionRules": [
+                      {
+                        "name": "redirected from 咲い"
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "笑い",
+                    "reading": "わらい",
+                    "sources": [
+                      {
+                        "originalText": "咲い",
+                        "transformedText": "咲い",
+                        "deinflectedText": "笑い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1928",
+                    "displayValueParsed": false,
+                    "frequency": 1928,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "58197㋕",
+                    "displayValueParsed": false,
+                    "frequency": 58197,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2512",
+                    "displayValueParsed": false,
+                    "frequency": 2512,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "94974㋕",
+                    "displayValueParsed": false,
+                    "frequency": 94974,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2233,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "咲う",
+                    "reading": "咲う",
+                    "sources": [
+                      {
+                        "originalText": "咲い",
+                        "transformedText": "咲い",
+                        "deinflectedText": "咲う",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "both",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      },
+                      {
+                        "name": "redirected from 咲う"
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "笑う",
+                    "reading": "わらう",
+                    "sources": [
+                      {
+                        "originalText": "咲い",
+                        "transformedText": "咲い",
+                        "deinflectedText": "笑う",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "461",
+                    "displayValueParsed": false,
+                    "frequency": 461,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23383㋕",
+                    "displayValueParsed": false,
+                    "frequency": 23383,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "334",
+                    "displayValueParsed": false,
+                    "frequency": 334,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "28640㋕",
+                    "displayValueParsed": false,
+                    "frequency": 28640,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1796,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "いた",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "板",
+                    "reading": "いた",
+                    "sources": [
+                      {
+                        "originalText": "いた",
+                        "transformedText": "いた",
+                        "deinflectedText": "いた",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3948",
+                    "displayValueParsed": false,
+                    "frequency": 3948,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "39596㋕",
+                    "displayValueParsed": false,
+                    "frequency": 39596,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5934",
+                    "displayValueParsed": false,
+                    "frequency": 5934,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10576㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10576,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4495,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 112911,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "痛",
+                    "reading": "いた",
+                    "sources": [
+                      {
+                        "originalText": "いた",
+                        "transformedText": "いた",
+                        "deinflectedText": "いた",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "いる",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いた",
+                        "transformedText": "いた",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "701㋕",
+                    "displayValueParsed": false,
+                    "frequency": 701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "37㋕",
+                    "displayValueParsed": false,
+                    "frequency": 37,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "射る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いた",
+                        "transformedText": "いた",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8836",
+                    "displayValueParsed": false,
+                    "frequency": 8836,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15807",
+                    "displayValueParsed": false,
+                    "frequency": 15807,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 19354,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鋳る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いた",
+                        "transformedText": "いた",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "60104",
+                    "displayValueParsed": false,
+                    "frequency": 60104,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "83416",
+                    "displayValueParsed": false,
+                    "frequency": 83416,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 84432,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "沃る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いた",
+                        "transformedText": "いた",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "122431",
+                    "displayValueParsed": false,
+                    "frequency": 122431,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "率る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いた",
+                        "transformedText": "いた",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "100203",
+                    "displayValueParsed": false,
+                    "frequency": 100203,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "癒る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いた",
+                        "transformedText": "いた",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23034",
+                    "displayValueParsed": false,
+                    "frequency": 23034,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "43124",
+                    "displayValueParsed": false,
+                    "frequency": 43124,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 127378,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "将る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いた",
+                        "transformedText": "いた",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "212849",
+                    "displayValueParsed": false,
+                    "frequency": 212849,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いた",
+                        "transformedText": "いた",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3021",
+                    "displayValueParsed": false,
+                    "frequency": 3021,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "37㋕",
+                    "displayValueParsed": false,
+                    "frequency": 37,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2172",
+                    "displayValueParsed": false,
+                    "frequency": 2172,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 92231,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鑄る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いた",
+                        "transformedText": "いた",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "255560",
+                    "displayValueParsed": false,
+                    "frequency": 255560,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "206069",
+                    "displayValueParsed": false,
+                    "frequency": 206069,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "い",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亥",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47280",
+                    "displayValueParsed": false,
+                    "frequency": 47280,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "56084",
+                    "displayValueParsed": false,
+                    "frequency": 56084,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46249,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伊",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14364",
+                    "displayValueParsed": false,
+                    "frequency": 14364,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30166",
+                    "displayValueParsed": false,
+                    "frequency": 30166,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "位",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4902",
+                    "displayValueParsed": false,
+                    "frequency": 4902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4817",
+                    "displayValueParsed": false,
+                    "frequency": 4817,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 967,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134715,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15864",
+                    "displayValueParsed": false,
+                    "frequency": 15864,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19720",
+                    "displayValueParsed": false,
+                    "frequency": 19720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5024,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胃",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4320",
+                    "displayValueParsed": false,
+                    "frequency": 4320,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4265",
+                    "displayValueParsed": false,
+                    "frequency": 4265,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4335,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 94,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 92,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伍",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "井",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6111",
+                    "displayValueParsed": false,
+                    "frequency": 6111,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19958",
+                    "displayValueParsed": false,
+                    "frequency": 19958,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18798,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "偉",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "42742",
+                    "displayValueParsed": false,
+                    "frequency": 42742,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40683",
+                    "displayValueParsed": false,
+                    "frequency": 40683,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65831㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62518,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夷",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75303",
+                    "displayValueParsed": false,
+                    "frequency": 75303,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 85253,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "委",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "42381",
+                    "displayValueParsed": false,
+                    "frequency": 42381,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23040,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "威",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27002",
+                    "displayValueParsed": false,
+                    "frequency": 27002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36921",
+                    "displayValueParsed": false,
+                    "frequency": 36921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30452,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126695,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45301",
+                    "displayValueParsed": false,
+                    "frequency": 45301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236493",
+                    "displayValueParsed": false,
+                    "frequency": 236493,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "彙",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "105649",
+                    "displayValueParsed": false,
+                    "frequency": 105649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160667",
+                    "displayValueParsed": false,
+                    "frequency": 160667,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "意",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4338",
+                    "displayValueParsed": false,
+                    "frequency": 4338,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4069",
+                    "displayValueParsed": false,
+                    "frequency": 4069,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5912,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "易",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 138689,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "汝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "猪",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "118901",
+                    "displayValueParsed": false,
+                    "frequency": 118901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "異",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14852",
+                    "displayValueParsed": false,
+                    "frequency": 14852,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15812",
+                    "displayValueParsed": false,
+                    "frequency": 15812,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4892,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "た",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "た",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "他",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 163,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 113090,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "多",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5815",
+                    "displayValueParsed": false,
+                    "frequency": 5815,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8609",
+                    "displayValueParsed": false,
+                    "frequency": 8609,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4965,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126617,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "田",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2236",
+                    "displayValueParsed": false,
+                    "frequency": 2236,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10070",
+                    "displayValueParsed": false,
+                    "frequency": 10070,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 20971,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 148593,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "咫",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "美しい",
+              "reading": "うつくしい"
+            },
+            {
+              "term": "花が咲く",
+              "reading": "はながさいた"
+            },
+            {
+              "term": "花が咲いた",
+              "reading": "はながさいた"
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "美しい",
+              "reading": "うつくしい",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 674,
+              "displayValue": "674",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "美しい",
+              "reading": "うつくしい",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 30786,
+              "displayValue": "30786㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "美しい",
+              "reading": "うつくしい",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 859,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "美しい",
+              "reading": "うつくしい",
+              "dictionary": "CC100",
+              "hasReading": false,
+              "frequency": 106954,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "美しい",
+              "reading": "うつくしい",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 960,
+              "displayValue": "960",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "美しい",
+              "reading": "うつくしい",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 46183,
+              "displayValue": "46183㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "花が咲く",
+              "reading": null
+            },
+            {
+              "term": "花が咲いた",
+              "reading": null
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "花が咲く",
+              "reading": "はながさく",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 7166,
+              "displayValue": "7166",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "花が咲く",
+              "reading": "はながさく",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 196908,
+              "displayValue": "196908㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "花が咲く",
+              "reading": "はながさく",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 8761,
+              "displayValue": "8761",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "花が咲く",
+              "reading": "はながさく",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 133002,
+              "displayValue": "133002㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      }
+    ],
+    "scripts": [
+      {
+        "sha256": "fb64f047eb0494f136bb92311df43c5318873298fe3efad6bfa82e5d531a93e1",
+        "marker": "optionsGetFull",
+        "result": {
+          "profileIndex": 0,
+          "scanLength": 21,
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ],
+          "dictionaryPriorityByName": {
+            "Jitendex.org [2026-03-05]": 0,
+            "日本語文法辞典(全集)": 1,
+            "JPDBv2㋕": 2,
+            "Jiten": 3,
+            "CC100": 4,
+            "実用日本語表現辞典": 5,
+            "NHK": 6,
+            "SubMiner Character Dictionary": 7
+          },
+          "dictionaryFrequencyModeByName": {
+            "JPDBv2㋕": "rank-based",
+            "Jiten": "rank-based"
+          }
+        }
+      },
+      {
+        "sha256": "2f533449657d2cf4b59c8897b115773acb6dcbe591a47dd0951e340ea7a7c82c",
+        "marker": "parseText",
+        "result": [
+          {
+            "id": "scan",
+            "source": "scanning-parser",
+            "dictionary": null,
+            "index": 0,
+            "content": [
+              [
+                {
+                  "text": "美",
+                  "reading": "うつく",
+                  "headwords": [
+                    [
+                      {
+                        "term": "美しい",
+                        "reading": "うつくしい",
+                        "sources": [
+                          {
+                            "originalText": "美しい",
+                            "transformedText": "美しい",
+                            "deinflectedText": "美しい",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "text": "しい",
+                  "reading": ""
+                }
+              ],
+              [
+                {
+                  "text": "花",
+                  "reading": "はな",
+                  "headwords": [
+                    [
+                      {
+                        "term": "花が咲く",
+                        "reading": "はながさく",
+                        "sources": [
+                          {
+                            "originalText": "花が咲いた",
+                            "transformedText": "花が咲いた",
+                            "deinflectedText": "花が咲く",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "text": "が",
+                  "reading": ""
+                },
+                {
+                  "text": "咲",
+                  "reading": "さ"
+                },
+                {
+                  "text": "いた",
+                  "reading": ""
+                }
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "4c8f03a78e8850bb183e94db7cbc48d6409b8bad71219358224015c40a7c3405",
+        "marker": "termsFind",
+        "result": [
+          {
+            "surface": "美しい",
+            "reading": "うつくしい",
+            "headword": "美しい",
+            "headwordReading": "うつくしい",
+            "startPos": 0,
+            "endPos": 3,
+            "isNameMatch": false,
+            "frequencyRank": 674,
+            "wordClasses": [
+              "adj-i"
+            ]
+          },
+          {
+            "surface": "花が咲いた",
+            "reading": "はながさいた",
+            "headword": "花が咲く",
+            "headwordReading": "はながさく",
+            "startPos": 3,
+            "endPos": 8,
+            "isNameMatch": false,
+            "frequencyRank": 7166,
+            "wordClasses": [
+              "v5"
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "6a61eb05b9ab6c3338a3c242f0adf9eede302bcd818e4e410d0ce5c444f40c4d",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "美しい",
+            "reading": "うつくしい",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 674,
+            "displayValue": "674",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "美しい",
+            "reading": "うつくしい",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 30786,
+            "displayValue": "30786㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "美しい",
+            "reading": "うつくしい",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 859,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "美しい",
+            "reading": "うつくしい",
+            "dictionary": "CC100",
+            "hasReading": false,
+            "frequency": 106954,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "美しい",
+            "reading": "うつくしい",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 960,
+            "displayValue": "960",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "美しい",
+            "reading": "うつくしい",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 46183,
+            "displayValue": "46183㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      },
+      {
+        "sha256": "b18b89fc268bb31d856e905111541b553eaac71c3b4efdcf261b7e382a409ea0",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "花が咲く",
+            "reading": "はながさく",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 7166,
+            "displayValue": "7166",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "花が咲く",
+            "reading": "はながさく",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 196908,
+            "displayValue": "196908㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "花が咲く",
+            "reading": "はながさく",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 8761,
+            "displayValue": "8761",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "花が咲く",
+            "reading": "はながさく",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 133002,
+            "displayValue": "133002㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      }
+    ],
+    "mecab": {
+      "美しい花が咲いた": [
+        {
+          "word": "美しい",
+          "partOfSpeech": "i_adjective",
+          "pos1": "形容詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "形容詞・イ段",
+          "inflectionForm": "基本形",
+          "headword": "美しい",
+          "katakanaReading": "ウツクシイ",
+          "pronunciation": "ウツクシイ"
+        },
+        {
+          "word": "花",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "一般",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "花",
+          "katakanaReading": "ハナ",
+          "pronunciation": "ハナ"
+        },
+        {
+          "word": "が",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "格助詞",
+          "pos3": "一般",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "が",
+          "katakanaReading": "ガ",
+          "pronunciation": "ガ"
+        },
+        {
+          "word": "咲い",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "五段・カ行イ音便",
+          "inflectionForm": "連用タ接続",
+          "headword": "咲く",
+          "katakanaReading": "サイ",
+          "pronunciation": "サイ"
+        },
+        {
+          "word": "た",
+          "partOfSpeech": "bound_auxiliary",
+          "pos1": "助動詞",
+          "pos2": "*",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "特殊・タ",
+          "inflectionForm": "基本形",
+          "headword": "た",
+          "katakanaReading": "タ",
+          "pronunciation": "タ"
+        }
+      ]
+    }
+  },
+  "expected": {
+    "tokens": [
+      {
+        "surface": "美しい",
+        "reading": "うつくしい",
+        "headword": "美しい",
+        "startPos": 0,
+        "endPos": 3,
+        "partOfSpeech": "i_adjective",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "うつくしい",
+        "pos1": "形容詞",
+        "pos2": "自立",
+        "pos3": "*",
+        "jlptLevel": "N4",
+        "frequencyRank": 674
+      },
+      {
+        "surface": "花が咲いた",
+        "reading": "はながさいた",
+        "headword": "花が咲く",
+        "startPos": 3,
+        "endPos": 8,
+        "partOfSpeech": "verb",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "はながさく",
+        "pos1": "動詞",
+        "pos2": "一般|格助詞|自立",
+        "pos3": "*|一般",
+        "frequencyRank": 7166
+      }
+    ]
+  }
+}

--- a/src/core/services/tokenizer/__fixtures__/golden/kanji-hijiritsu-noun.json
+++ b/src/core/services/tokenizer/__fixtures__/golden/kanji-hijiritsu-noun.json
@@ -1,0 +1,21736 @@
+{
+  "name": "kanji-hijiritsu-noun",
+  "description": "kanji non-independent noun (wake) keeps frequency/JLPT annotation",
+  "issueRefs": [
+    "#150"
+  ],
+  "recordedAt": "2026-07-11T00:49:39.796Z",
+  "input": {
+    "text": "そういう訳にはいかない"
+  },
+  "config": {},
+  "recording": {
+    "messages": [
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "parseText",
+        "params": {
+          "text": "そういう訳にはいかない",
+          "optionsContext": {
+            "index": 0
+          },
+          "scanLength": 21,
+          "useInternalParser": true,
+          "useMecabParser": false
+        },
+        "response": {
+          "result": [
+            {
+              "id": "scan",
+              "source": "scanning-parser",
+              "dictionary": null,
+              "index": 0,
+              "content": [
+                [
+                  {
+                    "text": "そういう",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "そう言う",
+                          "reading": "そういう",
+                          "sources": [
+                            {
+                              "originalText": "そういう",
+                              "transformedText": "そういう",
+                              "deinflectedText": "そういう",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "然う言う",
+                          "reading": "そういう",
+                          "sources": [
+                            {
+                              "originalText": "そういう",
+                              "transformedText": "そういう",
+                              "deinflectedText": "そういう",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "訳",
+                    "reading": "わけ",
+                    "headwords": [
+                      [
+                        {
+                          "term": "訳にはいかない",
+                          "reading": "わけにはいかない",
+                          "sources": [
+                            {
+                              "originalText": "訳にはいかない",
+                              "transformedText": "訳にはいかない",
+                              "deinflectedText": "訳にはいかない",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "訳にはいかない",
+                          "reading": "わけにはいかない",
+                          "sources": [
+                            {
+                              "originalText": "訳にはいかない",
+                              "transformedText": "訳にはいかない",
+                              "deinflectedText": "訳にはいかない",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "text": "にはいかない",
+                    "reading": ""
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "そういう訳にはいかない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "そう言う",
+                    "reading": "そういう",
+                    "sources": [
+                      {
+                        "originalText": "そういう",
+                        "transformedText": "そういう",
+                        "deinflectedText": "そういう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "253㋕",
+                    "displayValueParsed": false,
+                    "frequency": 253,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1465",
+                    "displayValueParsed": false,
+                    "frequency": 1465,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "398㋕",
+                    "displayValueParsed": false,
+                    "frequency": 398,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2319",
+                    "displayValueParsed": false,
+                    "frequency": 2319,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "然う言う",
+                    "reading": "そういう",
+                    "sources": [
+                      {
+                        "originalText": "そういう",
+                        "transformedText": "そういう",
+                        "deinflectedText": "そういう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "253㋕",
+                    "displayValueParsed": false,
+                    "frequency": 253,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "240539",
+                    "displayValueParsed": false,
+                    "frequency": 240539,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "創意",
+                    "reading": "そうい",
+                    "sources": [
+                      {
+                        "originalText": "そうい",
+                        "transformedText": "そうい",
+                        "deinflectedText": "そうい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "62573",
+                    "displayValueParsed": false,
+                    "frequency": 62573,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "284010㋕",
+                    "displayValueParsed": false,
+                    "frequency": 284010,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "78028",
+                    "displayValueParsed": false,
+                    "frequency": 78028,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 14475,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "相違",
+                    "reading": "そうい",
+                    "sources": [
+                      {
+                        "originalText": "そうい",
+                        "transformedText": "そうい",
+                        "deinflectedText": "そうい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6858",
+                    "displayValueParsed": false,
+                    "frequency": 6858,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75964㋕",
+                    "displayValueParsed": false,
+                    "frequency": 75964,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17053",
+                    "displayValueParsed": false,
+                    "frequency": 17053,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47246㋕",
+                    "displayValueParsed": false,
+                    "frequency": 47246,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 7823,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "総意",
+                    "reading": "そうい",
+                    "sources": [
+                      {
+                        "originalText": "そうい",
+                        "transformedText": "そうい",
+                        "deinflectedText": "そうい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22170",
+                    "displayValueParsed": false,
+                    "frequency": 22170,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21220",
+                    "displayValueParsed": false,
+                    "frequency": 21220,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27173,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "僧位",
+                    "reading": "そうい",
+                    "sources": [
+                      {
+                        "originalText": "そうい",
+                        "transformedText": "そうい",
+                        "deinflectedText": "そうい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "189939",
+                    "displayValueParsed": false,
+                    "frequency": 189939,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "252773",
+                    "displayValueParsed": false,
+                    "frequency": 252773,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 122945,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "僧衣",
+                    "reading": "そうい",
+                    "sources": [
+                      {
+                        "originalText": "そうい",
+                        "transformedText": "そうい",
+                        "deinflectedText": "そうい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "53505",
+                    "displayValueParsed": false,
+                    "frequency": 53505,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "86392",
+                    "displayValueParsed": false,
+                    "frequency": 86392,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "創痍",
+                    "reading": "そうい",
+                    "sources": [
+                      {
+                        "originalText": "そうい",
+                        "transformedText": "そうい",
+                        "deinflectedText": "そうい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "128054",
+                    "displayValueParsed": false,
+                    "frequency": 128054,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "271476㋕",
+                    "displayValueParsed": false,
+                    "frequency": 271476,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "163267",
+                    "displayValueParsed": false,
+                    "frequency": 163267,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 44844,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "相異",
+                    "reading": "そうい",
+                    "sources": [
+                      {
+                        "originalText": "そうい",
+                        "transformedText": "そうい",
+                        "deinflectedText": "そうい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75964㋕",
+                    "displayValueParsed": false,
+                    "frequency": 75964,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "76774",
+                    "displayValueParsed": false,
+                    "frequency": 76774,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47246㋕",
+                    "displayValueParsed": false,
+                    "frequency": 47246,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "142461",
+                    "displayValueParsed": false,
+                    "frequency": 142461,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 87189,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "そう",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "31㋕",
+                    "displayValueParsed": false,
+                    "frequency": 31,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7601㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "67301㋕",
+                    "displayValueParsed": false,
+                    "frequency": 67301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "71601㋕",
+                    "displayValueParsed": false,
+                    "frequency": 71601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "165901㋕",
+                    "displayValueParsed": false,
+                    "frequency": 165901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "255001㋕",
+                    "displayValueParsed": false,
+                    "frequency": 255001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "27㋕",
+                    "displayValueParsed": false,
+                    "frequency": 27,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 60,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "沿う",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7601㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7736",
+                    "displayValueParsed": false,
+                    "frequency": 7736,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "9775",
+                    "displayValueParsed": false,
+                    "frequency": 9775,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "27190㋕",
+                    "displayValueParsed": false,
+                    "frequency": 27190,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2412,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "添う",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14054",
+                    "displayValueParsed": false,
+                    "frequency": 14054,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "26889",
+                    "displayValueParsed": false,
+                    "frequency": 26889,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 29542,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "僧",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "13461",
+                    "displayValueParsed": false,
+                    "frequency": 13461,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "71601㋕",
+                    "displayValueParsed": false,
+                    "frequency": 71601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "27456",
+                    "displayValueParsed": false,
+                    "frequency": 27456,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "92097㋕",
+                    "displayValueParsed": false,
+                    "frequency": 92097,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 13904,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "双",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8857",
+                    "displayValueParsed": false,
+                    "frequency": 8857,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "255001㋕",
+                    "displayValueParsed": false,
+                    "frequency": 255001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15501",
+                    "displayValueParsed": false,
+                    "frequency": 15501,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "104901㋕",
+                    "displayValueParsed": false,
+                    "frequency": 104901,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22777,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "想",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "19617",
+                    "displayValueParsed": false,
+                    "frequency": 19617,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21038",
+                    "displayValueParsed": false,
+                    "frequency": 21038,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 32568,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "総",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5452",
+                    "displayValueParsed": false,
+                    "frequency": 5452,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "9025",
+                    "displayValueParsed": false,
+                    "frequency": 9025,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3386,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 142443,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "副う",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "131784",
+                    "displayValueParsed": false,
+                    "frequency": 131784,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "182770",
+                    "displayValueParsed": false,
+                    "frequency": 182770,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 93003,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "喪",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "操",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 43782,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 143204,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 97,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "箏",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "110332㋕",
+                    "displayValueParsed": false,
+                    "frequency": 110332,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 52377,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 102212,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 96,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "筝",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "110332㋕",
+                    "displayValueParsed": false,
+                    "frequency": 110332,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 73669,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "疎雨",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "叟",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "85865",
+                    "displayValueParsed": false,
+                    "frequency": 85865,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "114894",
+                    "displayValueParsed": false,
+                    "frequency": 114894,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 90644,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "叢",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "89738",
+                    "displayValueParsed": false,
+                    "frequency": 89738,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "101737",
+                    "displayValueParsed": false,
+                    "frequency": 101737,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 33833,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "壮",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "38649",
+                    "displayValueParsed": false,
+                    "frequency": 38649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "67301㋕",
+                    "displayValueParsed": false,
+                    "frequency": 67301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "52914",
+                    "displayValueParsed": false,
+                    "frequency": 52914,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "164173㋕",
+                    "displayValueParsed": false,
+                    "frequency": 164173,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 53842,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "奏",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18828",
+                    "displayValueParsed": false,
+                    "frequency": 18828,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23209",
+                    "displayValueParsed": false,
+                    "frequency": 23209,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 21147,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "宋",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34163",
+                    "displayValueParsed": false,
+                    "frequency": 34163,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "54850",
+                    "displayValueParsed": false,
+                    "frequency": 54850,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 29915,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "宗",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "36485",
+                    "displayValueParsed": false,
+                    "frequency": 36485,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47003",
+                    "displayValueParsed": false,
+                    "frequency": 47003,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 59564,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 137816,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "層",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4532",
+                    "displayValueParsed": false,
+                    "frequency": 4532,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6505",
+                    "displayValueParsed": false,
+                    "frequency": 6505,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2409,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "惣",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "42806",
+                    "displayValueParsed": false,
+                    "frequency": 42806,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "67200",
+                    "displayValueParsed": false,
+                    "frequency": 67200,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 52284,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "曹",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47536",
+                    "displayValueParsed": false,
+                    "frequency": 47536,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "53276",
+                    "displayValueParsed": false,
+                    "frequency": 53276,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 60538,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "槽",
+                    "reading": "そう",
+                    "sources": [
+                      {
+                        "originalText": "そう",
+                        "transformedText": "そう",
+                        "deinflectedText": "そう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34633",
+                    "displayValueParsed": false,
+                    "frequency": 34633,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22610,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 4
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ういう訳にはいかない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "羽衣",
+                    "reading": "うい",
+                    "sources": [
+                      {
+                        "originalText": "うい",
+                        "transformedText": "うい",
+                        "deinflectedText": "うい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "初",
+                    "reading": "うい",
+                    "sources": [
+                      {
+                        "originalText": "うい",
+                        "transformedText": "うい",
+                        "deinflectedText": "うい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10390㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10390,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "303931",
+                    "displayValueParsed": false,
+                    "frequency": 303931,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "愛い",
+                    "reading": "うい",
+                    "sources": [
+                      {
+                        "originalText": "うい",
+                        "transformedText": "うい",
+                        "deinflectedText": "うい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "150229",
+                    "displayValueParsed": false,
+                    "frequency": 150229,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "42303",
+                    "displayValueParsed": false,
+                    "frequency": 42303,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "憂い",
+                    "reading": "うい",
+                    "sources": [
+                      {
+                        "originalText": "うい",
+                        "transformedText": "うい",
+                        "deinflectedText": "うい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "17392㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17392,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18101",
+                    "displayValueParsed": false,
+                    "frequency": 18101,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36749",
+                    "displayValueParsed": false,
+                    "frequency": 36749,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "107006㋕",
+                    "displayValueParsed": false,
+                    "frequency": 107006,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 72192,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 159888,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有為",
+                    "reading": "うい",
+                    "sources": [
+                      {
+                        "originalText": "うい",
+                        "transformedText": "うい",
+                        "deinflectedText": "うい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "114001",
+                    "displayValueParsed": false,
+                    "frequency": 114001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "120530",
+                    "displayValueParsed": false,
+                    "frequency": 120530,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 87717,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "雨意",
+                    "reading": "うい",
+                    "sources": [
+                      {
+                        "originalText": "うい",
+                        "transformedText": "うい",
+                        "deinflectedText": "うい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "264167",
+                    "displayValueParsed": false,
+                    "frequency": 264167,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ウイ",
+                    "reading": "ウイ",
+                    "sources": [
+                      {
+                        "originalText": "うい",
+                        "transformedText": "ウイ",
+                        "deinflectedText": "ウイ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "43714㋕",
+                    "displayValueParsed": false,
+                    "frequency": 43714,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15134㋕",
+                    "displayValueParsed": false,
+                    "frequency": 15134,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 61758,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "う",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "206㋕",
+                    "displayValueParsed": false,
+                    "frequency": 206,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9411,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "卯",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "40163",
+                    "displayValueParsed": false,
+                    "frequency": 40163,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "61505",
+                    "displayValueParsed": false,
+                    "frequency": 61505,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 55581,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 147477,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "宇",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "41402",
+                    "displayValueParsed": false,
+                    "frequency": 41402,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46946,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 159206,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "得",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "46669㋕",
+                    "displayValueParsed": false,
+                    "frequency": 46669,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "111527",
+                    "displayValueParsed": false,
+                    "frequency": 111527,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "33602",
+                    "displayValueParsed": false,
+                    "frequency": 33602,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "61060",
+                    "displayValueParsed": false,
+                    "frequency": 61060,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18901,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145835,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "竽",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "247924",
+                    "displayValueParsed": false,
+                    "frequency": 247924,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "279165",
+                    "displayValueParsed": false,
+                    "frequency": 279165,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "羽",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "62501",
+                    "displayValueParsed": false,
+                    "frequency": 62501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "117275",
+                    "displayValueParsed": false,
+                    "frequency": 117275,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 115134,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 122375,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鵜",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "31146",
+                    "displayValueParsed": false,
+                    "frequency": 31146,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "66994",
+                    "displayValueParsed": false,
+                    "frequency": 66994,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 35994,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "諾",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鰻",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -104,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "兎",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "優",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 159848,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ウ",
+                    "reading": "ウ",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "ウ",
+                        "deinflectedText": "ウ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18682㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18682,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "71893㋕",
+                    "displayValueParsed": false,
+                    "frequency": 71893,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3466㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3466,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 15980,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "いう訳にはいかない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "言う",
+                    "reading": "いう",
+                    "sources": [
+                      {
+                        "originalText": "いう",
+                        "transformedText": "いう",
+                        "deinflectedText": "いう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27",
+                    "displayValueParsed": false,
+                    "frequency": 27,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "86㋕",
+                    "displayValueParsed": false,
+                    "frequency": 86,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "26",
+                    "displayValueParsed": false,
+                    "frequency": 26,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "74㋕",
+                    "displayValueParsed": false,
+                    "frequency": 74,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 61732,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "結う",
+                    "reading": "いう",
+                    "sources": [
+                      {
+                        "originalText": "いう",
+                        "transformedText": "いう",
+                        "deinflectedText": "いう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 131384,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "云う",
+                    "reading": "いう",
+                    "sources": [
+                      {
+                        "originalText": "いう",
+                        "transformedText": "いう",
+                        "deinflectedText": "いう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "86㋕",
+                    "displayValueParsed": false,
+                    "frequency": 86,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8261",
+                    "displayValueParsed": false,
+                    "frequency": 8261,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "74㋕",
+                    "displayValueParsed": false,
+                    "frequency": 74,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25290",
+                    "displayValueParsed": false,
+                    "frequency": 25290,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 12010,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 113621,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "謂う",
+                    "reading": "いう",
+                    "sources": [
+                      {
+                        "originalText": "いう",
+                        "transformedText": "いう",
+                        "deinflectedText": "いう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "86㋕",
+                    "displayValueParsed": false,
+                    "frequency": 86,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "32406",
+                    "displayValueParsed": false,
+                    "frequency": 32406,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "74㋕",
+                    "displayValueParsed": false,
+                    "frequency": 74,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "67826",
+                    "displayValueParsed": false,
+                    "frequency": 67826,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 61691,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 137807,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "い",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亥",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47280",
+                    "displayValueParsed": false,
+                    "frequency": 47280,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "56084",
+                    "displayValueParsed": false,
+                    "frequency": 56084,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46249,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伊",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14364",
+                    "displayValueParsed": false,
+                    "frequency": 14364,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30166",
+                    "displayValueParsed": false,
+                    "frequency": 30166,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "位",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4902",
+                    "displayValueParsed": false,
+                    "frequency": 4902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4817",
+                    "displayValueParsed": false,
+                    "frequency": 4817,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 967,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134715,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15864",
+                    "displayValueParsed": false,
+                    "frequency": 15864,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19720",
+                    "displayValueParsed": false,
+                    "frequency": 19720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5024,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胃",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4320",
+                    "displayValueParsed": false,
+                    "frequency": 4320,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4265",
+                    "displayValueParsed": false,
+                    "frequency": 4265,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4335,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 94,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 92,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伍",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "井",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6111",
+                    "displayValueParsed": false,
+                    "frequency": 6111,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19958",
+                    "displayValueParsed": false,
+                    "frequency": 19958,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18798,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "偉",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "42742",
+                    "displayValueParsed": false,
+                    "frequency": 42742,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40683",
+                    "displayValueParsed": false,
+                    "frequency": 40683,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65831㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62518,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夷",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75303",
+                    "displayValueParsed": false,
+                    "frequency": 75303,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 85253,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "委",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "42381",
+                    "displayValueParsed": false,
+                    "frequency": 42381,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23040,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "威",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27002",
+                    "displayValueParsed": false,
+                    "frequency": 27002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36921",
+                    "displayValueParsed": false,
+                    "frequency": 36921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30452,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126695,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45301",
+                    "displayValueParsed": false,
+                    "frequency": 45301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236493",
+                    "displayValueParsed": false,
+                    "frequency": 236493,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "彙",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "105649",
+                    "displayValueParsed": false,
+                    "frequency": 105649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160667",
+                    "displayValueParsed": false,
+                    "frequency": 160667,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "意",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4338",
+                    "displayValueParsed": false,
+                    "frequency": 4338,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4069",
+                    "displayValueParsed": false,
+                    "frequency": 4069,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5912,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "易",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 138689,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "汝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "猪",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "118901",
+                    "displayValueParsed": false,
+                    "frequency": 118901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "異",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14852",
+                    "displayValueParsed": false,
+                    "frequency": 14852,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15812",
+                    "displayValueParsed": false,
+                    "frequency": 15812,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4892,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胆",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145167,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "藺",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "94214",
+                    "displayValueParsed": false,
+                    "frequency": 94214,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "138991",
+                    "displayValueParsed": false,
+                    "frequency": 138991,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 99348,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "衣",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24121,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132574,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豬",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "200568",
+                    "displayValueParsed": false,
+                    "frequency": 200568,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "196521",
+                    "displayValueParsed": false,
+                    "frequency": 196521,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豕",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -6,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "緯",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 96278,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "寝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "う訳にはいかない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "う",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "206㋕",
+                    "displayValueParsed": false,
+                    "frequency": 206,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9411,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "卯",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "40163",
+                    "displayValueParsed": false,
+                    "frequency": 40163,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "61505",
+                    "displayValueParsed": false,
+                    "frequency": 61505,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 55581,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 147477,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "宇",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "41402",
+                    "displayValueParsed": false,
+                    "frequency": 41402,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46946,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 159206,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "得",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "46669㋕",
+                    "displayValueParsed": false,
+                    "frequency": 46669,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "111527",
+                    "displayValueParsed": false,
+                    "frequency": 111527,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "33602",
+                    "displayValueParsed": false,
+                    "frequency": 33602,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "61060",
+                    "displayValueParsed": false,
+                    "frequency": 61060,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18901,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145835,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "竽",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "247924",
+                    "displayValueParsed": false,
+                    "frequency": 247924,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "279165",
+                    "displayValueParsed": false,
+                    "frequency": 279165,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "羽",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "62501",
+                    "displayValueParsed": false,
+                    "frequency": 62501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "117275",
+                    "displayValueParsed": false,
+                    "frequency": 117275,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 115134,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 122375,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鵜",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "31146",
+                    "displayValueParsed": false,
+                    "frequency": 31146,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "66994",
+                    "displayValueParsed": false,
+                    "frequency": 66994,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 35994,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "諾",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鰻",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -104,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "兎",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "優",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 159848,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ウ",
+                    "reading": "ウ",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "ウ",
+                        "deinflectedText": "ウ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18682㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18682,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "71893㋕",
+                    "displayValueParsed": false,
+                    "frequency": 71893,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3466㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3466,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 15980,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "訳にはいかない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 7,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "訳にはいかない",
+                    "reading": "わけにはいかない",
+                    "sources": [
+                      {
+                        "originalText": "訳にはいかない",
+                        "transformedText": "訳にはいかない",
+                        "deinflectedText": "訳にはいかない",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1715㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1715,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11293",
+                    "displayValueParsed": false,
+                    "frequency": 11293,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1563㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1563,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15072",
+                    "displayValueParsed": false,
+                    "frequency": 15072,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "訳",
+                    "reading": "わけ",
+                    "sources": [
+                      {
+                        "originalText": "訳",
+                        "transformedText": "訳",
+                        "deinflectedText": "訳",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "154㋕",
+                    "displayValueParsed": false,
+                    "frequency": 154,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1756",
+                    "displayValueParsed": false,
+                    "frequency": 1756,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160㋕",
+                    "displayValueParsed": false,
+                    "frequency": 160,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1940",
+                    "displayValueParsed": false,
+                    "frequency": 1940,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 186,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "訳",
+                    "reading": "やく",
+                    "sources": [
+                      {
+                        "originalText": "訳",
+                        "transformedText": "訳",
+                        "deinflectedText": "訳",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12401",
+                    "displayValueParsed": false,
+                    "frequency": 12401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "84801㋕",
+                    "displayValueParsed": false,
+                    "frequency": 84801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12874",
+                    "displayValueParsed": false,
+                    "frequency": 12874,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995㋕",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16721,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 7
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "にはいかない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "二拝",
+                    "reading": "にはい",
+                    "sources": [
+                      {
+                        "originalText": "にはい",
+                        "transformedText": "にはい",
+                        "deinflectedText": "にはい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "には",
+                    "reading": "には",
+                    "sources": [
+                      {
+                        "originalText": "には",
+                        "transformedText": "には",
+                        "deinflectedText": "には",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22㋕",
+                    "displayValueParsed": false,
+                    "frequency": 22,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "33㋕",
+                    "displayValueParsed": false,
+                    "frequency": 33,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "に",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "二",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "532",
+                    "displayValueParsed": false,
+                    "frequency": 532,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1248",
+                    "displayValueParsed": false,
+                    "frequency": 1248,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 409,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 146150,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "荷",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9741",
+                    "displayValueParsed": false,
+                    "frequency": 9741,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12347",
+                    "displayValueParsed": false,
+                    "frequency": 12347,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "93107㋕",
+                    "displayValueParsed": false,
+                    "frequency": 93107,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16472,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "２",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6080",
+                    "displayValueParsed": false,
+                    "frequency": 6080,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "185002",
+                    "displayValueParsed": false,
+                    "frequency": 185002,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 98,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "弐",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27603",
+                    "displayValueParsed": false,
+                    "frequency": 27603,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "33961",
+                    "displayValueParsed": false,
+                    "frequency": 33961,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 45426,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 97,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "弍",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "176149",
+                    "displayValueParsed": false,
+                    "frequency": 176149,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236571",
+                    "displayValueParsed": false,
+                    "frequency": 236571,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 95,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "貮",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "213932",
+                    "displayValueParsed": false,
+                    "frequency": 213932,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "253770",
+                    "displayValueParsed": false,
+                    "frequency": 253770,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "丹",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23215",
+                    "displayValueParsed": false,
+                    "frequency": 23215,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "38056",
+                    "displayValueParsed": false,
+                    "frequency": 38056,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 47796,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 133516,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "似",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15588",
+                    "displayValueParsed": false,
+                    "frequency": 15588,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "18831",
+                    "displayValueParsed": false,
+                    "frequency": 18831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 20085,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "土",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 112427,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "尼",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24925",
+                    "displayValueParsed": false,
+                    "frequency": 24925,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "39335",
+                    "displayValueParsed": false,
+                    "frequency": 39335,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26189,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "煮",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21728",
+                    "displayValueParsed": false,
+                    "frequency": 21728,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "32488",
+                    "displayValueParsed": false,
+                    "frequency": 32488,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 20677,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -104,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "貳",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "126258",
+                    "displayValueParsed": false,
+                    "frequency": 126258,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "138327",
+                    "displayValueParsed": false,
+                    "frequency": 138327,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "似る",
+                    "reading": "にる",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "にる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "398",
+                    "displayValueParsed": false,
+                    "frequency": 398,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "41989㋕",
+                    "displayValueParsed": false,
+                    "frequency": 41989,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "508",
+                    "displayValueParsed": false,
+                    "frequency": 508,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11843㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11843,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1135,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 131640,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "煮る",
+                    "reading": "にる",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "にる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9957",
+                    "displayValueParsed": false,
+                    "frequency": 9957,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10606",
+                    "displayValueParsed": false,
+                    "frequency": 10606,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "烹る",
+                    "reading": "にる",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "にる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "135057",
+                    "displayValueParsed": false,
+                    "frequency": 135057,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "141417",
+                    "displayValueParsed": false,
+                    "frequency": 141417,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ニ",
+                    "reading": "ニ",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "ニ",
+                        "deinflectedText": "ニ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12999㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12999,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "19284㋕",
+                    "displayValueParsed": false,
+                    "frequency": 19284,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "274744㋕",
+                    "displayValueParsed": false,
+                    "frequency": 274744,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26869,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "はいかない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "廃家",
+                    "reading": "はいか",
+                    "sources": [
+                      {
+                        "originalText": "はいか",
+                        "transformedText": "はいか",
+                        "deinflectedText": "はいか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "137857㋕",
+                    "displayValueParsed": false,
+                    "frequency": 137857,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "194992",
+                    "displayValueParsed": false,
+                    "frequency": 194992,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "177147",
+                    "displayValueParsed": false,
+                    "frequency": 177147,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 112183,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "配下",
+                    "reading": "はいか",
+                    "sources": [
+                      {
+                        "originalText": "はいか",
+                        "transformedText": "はいか",
+                        "deinflectedText": "はいか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8520",
+                    "displayValueParsed": false,
+                    "frequency": 8520,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "196154㋕",
+                    "displayValueParsed": false,
+                    "frequency": 196154,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12344",
+                    "displayValueParsed": false,
+                    "frequency": 12344,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995㋕",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18591,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "配架",
+                    "reading": "はいか",
+                    "sources": [
+                      {
+                        "originalText": "はいか",
+                        "transformedText": "はいか",
+                        "deinflectedText": "はいか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "158656",
+                    "displayValueParsed": false,
+                    "frequency": 158656,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "202216",
+                    "displayValueParsed": false,
+                    "frequency": 202216,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 48301,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "配荷",
+                    "reading": "はいか",
+                    "sources": [
+                      {
+                        "originalText": "はいか",
+                        "transformedText": "はいか",
+                        "deinflectedText": "はいか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "156647",
+                    "displayValueParsed": false,
+                    "frequency": 156647,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "243989",
+                    "displayValueParsed": false,
+                    "frequency": 243989,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "排架",
+                    "reading": "はいか",
+                    "sources": [
+                      {
+                        "originalText": "はいか",
+                        "transformedText": "はいか",
+                        "deinflectedText": "はいか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "347844",
+                    "displayValueParsed": false,
+                    "frequency": 347844,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ハイカ",
+                    "reading": "ハイカ",
+                    "sources": [
+                      {
+                        "originalText": "はいか",
+                        "transformedText": "ハイカ",
+                        "deinflectedText": "ハイカ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "258119㋕",
+                    "displayValueParsed": false,
+                    "frequency": 258119,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "127902㋕",
+                    "displayValueParsed": false,
+                    "frequency": 127902,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 94624,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "はい",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "446㋕",
+                    "displayValueParsed": false,
+                    "frequency": 446,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "91901㋕",
+                    "displayValueParsed": false,
+                    "frequency": 91901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "249201㋕",
+                    "displayValueParsed": false,
+                    "frequency": 249201,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "57㋕",
+                    "displayValueParsed": false,
+                    "frequency": 57,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2377,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "灰",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5411",
+                    "displayValueParsed": false,
+                    "frequency": 5411,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8047",
+                    "displayValueParsed": false,
+                    "frequency": 8047,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18913,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 130104,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "肺",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6311",
+                    "displayValueParsed": false,
+                    "frequency": 6311,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "249201㋕",
+                    "displayValueParsed": false,
+                    "frequency": 249201,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6972",
+                    "displayValueParsed": false,
+                    "frequency": 6972,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "46606㋕",
+                    "displayValueParsed": false,
+                    "frequency": 46606,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8761,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "佩",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "58130",
+                    "displayValueParsed": false,
+                    "frequency": 58130,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "102393",
+                    "displayValueParsed": false,
+                    "frequency": 102393,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132517,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "拝",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34475",
+                    "displayValueParsed": false,
+                    "frequency": 34475,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40956",
+                    "displayValueParsed": false,
+                    "frequency": 40956,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 42140,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "排",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "58628",
+                    "displayValueParsed": false,
+                    "frequency": 58628,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "60625",
+                    "displayValueParsed": false,
+                    "frequency": 60625,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22248,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "敗",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "19319",
+                    "displayValueParsed": false,
+                    "frequency": 19319,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "18042",
+                    "displayValueParsed": false,
+                    "frequency": 18042,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143㋕",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10233,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "杯",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5907",
+                    "displayValueParsed": false,
+                    "frequency": 5907,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "91901㋕",
+                    "displayValueParsed": false,
+                    "frequency": 91901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3521,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 111474,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "牌",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "62803",
+                    "displayValueParsed": false,
+                    "frequency": 62803,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "61715",
+                    "displayValueParsed": false,
+                    "frequency": 61715,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 40593,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 140092,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胚",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "73465",
+                    "displayValueParsed": false,
+                    "frequency": 73465,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "76696",
+                    "displayValueParsed": false,
+                    "frequency": 76696,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30436,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "蔤",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "294992",
+                    "displayValueParsed": false,
+                    "frequency": 294992,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "輩",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "100601",
+                    "displayValueParsed": false,
+                    "frequency": 100601,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "珮",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "192125",
+                    "displayValueParsed": false,
+                    "frequency": 192125,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "261753",
+                    "displayValueParsed": false,
+                    "frequency": 261753,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "盃",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "77702",
+                    "displayValueParsed": false,
+                    "frequency": 77702,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "91901㋕",
+                    "displayValueParsed": false,
+                    "frequency": 91901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "86511㋕",
+                    "displayValueParsed": false,
+                    "frequency": 86511,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 155087,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -4,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鮠",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -5,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鰷",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "廃",
+                    "reading": "はい",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18799,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "這う",
+                    "reading": "はう",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3715",
+                    "displayValueParsed": false,
+                    "frequency": 3715,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "51085㋕",
+                    "displayValueParsed": false,
+                    "frequency": 51085,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5467",
+                    "displayValueParsed": false,
+                    "frequency": 5467,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6355㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6355,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16969,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "匍う",
+                    "reading": "はう",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "51085㋕",
+                    "displayValueParsed": false,
+                    "frequency": 51085,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "96874",
+                    "displayValueParsed": false,
+                    "frequency": 96874,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6355㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6355,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160619",
+                    "displayValueParsed": false,
+                    "frequency": 160619,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "延う",
+                    "reading": "はう",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "はい",
+                        "deinflectedText": "はう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "51085㋕",
+                    "displayValueParsed": false,
+                    "frequency": 51085,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "118281",
+                    "displayValueParsed": false,
+                    "frequency": 118281,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6355㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6355,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "130083",
+                    "displayValueParsed": false,
+                    "frequency": 130083,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ハイ",
+                    "reading": "ハイ",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "ハイ",
+                        "deinflectedText": "ハイ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10568㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10568,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11402㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11402,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "104001㋕",
+                    "displayValueParsed": false,
+                    "frequency": 104001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5081㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5081,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4233,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "high",
+                    "reading": "ハイ",
+                    "sources": [
+                      {
+                        "originalText": "はい",
+                        "transformedText": "ハイ",
+                        "deinflectedText": "ハイ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "は",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 7,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "刃",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3237",
+                    "displayValueParsed": false,
+                    "frequency": 3237,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3789",
+                    "displayValueParsed": false,
+                    "frequency": 3789,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11385,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "歯",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2347",
+                    "displayValueParsed": false,
+                    "frequency": 2347,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2970",
+                    "displayValueParsed": false,
+                    "frequency": 2970,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1308,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "派",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2266",
+                    "displayValueParsed": false,
+                    "frequency": 2266,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2666",
+                    "displayValueParsed": false,
+                    "frequency": 2666,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3376,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "いかない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "negative",
+                        "description": "1. Negative form of verbs.\n2. Expresses a feeling of solicitation to the other party.\nUsage: Attach ない to the irrealis form (未然形) of verbs, くない to the stem of i-adjectives. ない itself conjugates as i-adjective. ます becomes ません."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "行く",
+                    "reading": "いく",
+                    "sources": [
+                      {
+                        "originalText": "いかない",
+                        "transformedText": "いかない",
+                        "deinflectedText": "いく",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "44",
+                    "displayValueParsed": false,
+                    "frequency": 44,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "65㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "64",
+                    "displayValueParsed": false,
+                    "frequency": 64,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "199㋕",
+                    "displayValueParsed": false,
+                    "frequency": 199,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 38,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 50649,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "negative",
+                        "description": "1. Negative form of verbs.\n2. Expresses a feeling of solicitation to the other party.\nUsage: Attach ない to the irrealis form (未然形) of verbs, くない to the stem of i-adjectives. ない itself conjugates as i-adjective. ます becomes ません."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "逝く",
+                    "reading": "いく",
+                    "sources": [
+                      {
+                        "originalText": "いかない",
+                        "transformedText": "いかない",
+                        "deinflectedText": "いく",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "65㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9328",
+                    "displayValueParsed": false,
+                    "frequency": 9328,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6753",
+                    "displayValueParsed": false,
+                    "frequency": 6753,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11419,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 140120,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "negative",
+                        "description": "1. Negative form of verbs.\n2. Expresses a feeling of solicitation to the other party.\nUsage: Attach ない to the irrealis form (未然形) of verbs, くない to the stem of i-adjectives. ない itself conjugates as i-adjective. ます becomes ません."
+                      }
+                    ]
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "往く",
+                    "reading": "いく",
+                    "sources": [
+                      {
+                        "originalText": "いかない",
+                        "transformedText": "いかない",
+                        "deinflectedText": "いく",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "65㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18835",
+                    "displayValueParsed": false,
+                    "frequency": 18835,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "199㋕",
+                    "displayValueParsed": false,
+                    "frequency": 199,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "31243",
+                    "displayValueParsed": false,
+                    "frequency": 31243,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 67255,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 133643,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "如何な",
+                    "reading": "いかな",
+                    "sources": [
+                      {
+                        "originalText": "いかな",
+                        "transformedText": "いかな",
+                        "deinflectedText": "いかな",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "17798㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17798,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "64108",
+                    "displayValueParsed": false,
+                    "frequency": 64108,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16207㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16207,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "57326",
+                    "displayValueParsed": false,
+                    "frequency": 57326,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24016,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 111437,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "以下",
+                    "reading": "いか",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "いか",
+                        "deinflectedText": "いか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2468",
+                    "displayValueParsed": false,
+                    "frequency": 2468,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2452",
+                    "displayValueParsed": false,
+                    "frequency": 2452,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10813㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10813,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 236,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医科",
+                    "reading": "いか",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "いか",
+                        "deinflectedText": "いか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "68330",
+                    "displayValueParsed": false,
+                    "frequency": 68330,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "76844",
+                    "displayValueParsed": false,
+                    "frequency": 76844,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10808,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "烏賊",
+                    "reading": "いか",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "いか",
+                        "deinflectedText": "いか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "52237",
+                    "displayValueParsed": false,
+                    "frequency": 52237,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11509,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五十日",
+                    "reading": "いか",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "いか",
+                        "deinflectedText": "いか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "64055",
+                    "displayValueParsed": false,
+                    "frequency": 64055,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 123954,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医家",
+                    "reading": "いか",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "いか",
+                        "deinflectedText": "いか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "101319",
+                    "displayValueParsed": false,
+                    "frequency": 101319,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "150542",
+                    "displayValueParsed": false,
+                    "frequency": 150542,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 73667,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "易化",
+                    "reading": "いか",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "いか",
+                        "deinflectedText": "いか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "異化",
+                    "reading": "いか",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "いか",
+                        "deinflectedText": "いか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "120481㋕",
+                    "displayValueParsed": false,
+                    "frequency": 120481,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "148390",
+                    "displayValueParsed": false,
+                    "frequency": 148390,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65154㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65154,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "161257",
+                    "displayValueParsed": false,
+                    "frequency": 161257,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 57426,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "衣架",
+                    "reading": "いか",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "いか",
+                        "deinflectedText": "いか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "凧",
+                    "reading": "いか",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "いか",
+                        "deinflectedText": "いか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 38526,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 119485,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "已下",
+                    "reading": "いか",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "いか",
+                        "deinflectedText": "いか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "289853",
+                    "displayValueParsed": false,
+                    "frequency": 289853,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10813㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10813,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "286883",
+                    "displayValueParsed": false,
+                    "frequency": 286883,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "紙鳶",
+                    "reading": "いか",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "いか",
+                        "deinflectedText": "いか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "イカ",
+                    "reading": "イカ",
+                    "sources": [
+                      {
+                        "originalText": "いか",
+                        "transformedText": "イカ",
+                        "deinflectedText": "イカ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11889㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11889,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "256240㋕",
+                    "displayValueParsed": false,
+                    "frequency": 256240,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10123㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10123,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 20342,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "い",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亥",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47280",
+                    "displayValueParsed": false,
+                    "frequency": 47280,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "56084",
+                    "displayValueParsed": false,
+                    "frequency": 56084,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46249,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伊",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14364",
+                    "displayValueParsed": false,
+                    "frequency": 14364,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30166",
+                    "displayValueParsed": false,
+                    "frequency": 30166,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "位",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4902",
+                    "displayValueParsed": false,
+                    "frequency": 4902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4817",
+                    "displayValueParsed": false,
+                    "frequency": 4817,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 967,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134715,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15864",
+                    "displayValueParsed": false,
+                    "frequency": 15864,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19720",
+                    "displayValueParsed": false,
+                    "frequency": 19720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5024,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胃",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4320",
+                    "displayValueParsed": false,
+                    "frequency": 4320,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4265",
+                    "displayValueParsed": false,
+                    "frequency": 4265,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4335,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 94,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 92,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伍",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "井",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6111",
+                    "displayValueParsed": false,
+                    "frequency": 6111,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19958",
+                    "displayValueParsed": false,
+                    "frequency": 19958,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18798,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "偉",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "42742",
+                    "displayValueParsed": false,
+                    "frequency": 42742,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40683",
+                    "displayValueParsed": false,
+                    "frequency": 40683,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65831㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62518,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夷",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75303",
+                    "displayValueParsed": false,
+                    "frequency": 75303,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 85253,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "委",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "42381",
+                    "displayValueParsed": false,
+                    "frequency": 42381,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23040,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "威",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27002",
+                    "displayValueParsed": false,
+                    "frequency": 27002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36921",
+                    "displayValueParsed": false,
+                    "frequency": 36921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30452,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126695,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45301",
+                    "displayValueParsed": false,
+                    "frequency": 45301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236493",
+                    "displayValueParsed": false,
+                    "frequency": 236493,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "彙",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "105649",
+                    "displayValueParsed": false,
+                    "frequency": 105649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160667",
+                    "displayValueParsed": false,
+                    "frequency": 160667,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 4
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "かない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "家内",
+                    "reading": "かない",
+                    "sources": [
+                      {
+                        "originalText": "かない",
+                        "transformedText": "かない",
+                        "deinflectedText": "かない",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "17447",
+                    "displayValueParsed": false,
+                    "frequency": 17447,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22778㋕",
+                    "displayValueParsed": false,
+                    "frequency": 22778,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "18491",
+                    "displayValueParsed": false,
+                    "frequency": 18491,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "75245㋕",
+                    "displayValueParsed": false,
+                    "frequency": 75245,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10960,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 127163,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "叶う",
+                    "reading": "かなう",
+                    "sources": [
+                      {
+                        "originalText": "かない",
+                        "transformedText": "かない",
+                        "deinflectedText": "かなう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2718㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2718,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3424",
+                    "displayValueParsed": false,
+                    "frequency": 3424,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1434㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1434,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3630",
+                    "displayValueParsed": false,
+                    "frequency": 3630,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4577,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "敵う",
+                    "reading": "かなう",
+                    "sources": [
+                      {
+                        "originalText": "かない",
+                        "transformedText": "かない",
+                        "deinflectedText": "かなう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2718㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2718,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5346",
+                    "displayValueParsed": false,
+                    "frequency": 5346,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "7856",
+                    "displayValueParsed": false,
+                    "frequency": 7856,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10113,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "適う",
+                    "reading": "かなう",
+                    "sources": [
+                      {
+                        "originalText": "かない",
+                        "transformedText": "かない",
+                        "deinflectedText": "かなう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2718㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2718,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21376",
+                    "displayValueParsed": false,
+                    "frequency": 21376,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "39349",
+                    "displayValueParsed": false,
+                    "frequency": 39349,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8241,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 111272,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "かな",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG上級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      },
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "130㋕",
+                    "displayValueParsed": false,
+                    "frequency": 130,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 24501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "115㋕",
+                    "displayValueParsed": false,
+                    "frequency": 115,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26541,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "仮名",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 24501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34143",
+                    "displayValueParsed": false,
+                    "frequency": 34143,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15460㋕",
+                    "displayValueParsed": false,
+                    "frequency": 15460,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "41349",
+                    "displayValueParsed": false,
+                    "frequency": 41349,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11667,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 152435,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "哉",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "28150",
+                    "displayValueParsed": false,
+                    "frequency": 28150,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "45567",
+                    "displayValueParsed": false,
+                    "frequency": 45567,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 44835,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 144331,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "仮字",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 24501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "198295",
+                    "displayValueParsed": false,
+                    "frequency": 198295,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 155824,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "金",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "69180",
+                    "displayValueParsed": false,
+                    "frequency": 69180,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 57007,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "假名",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 24501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "250374",
+                    "displayValueParsed": false,
+                    "frequency": 250374,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15460㋕",
+                    "displayValueParsed": false,
+                    "frequency": 15460,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "279165",
+                    "displayValueParsed": false,
+                    "frequency": 279165,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "Cana",
+                    "reading": "カナ",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "カナ",
+                        "deinflectedText": "カナ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "か",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 19,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "加",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "16448",
+                    "displayValueParsed": false,
+                    "frequency": 16448,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25781",
+                    "displayValueParsed": false,
+                    "frequency": 25781,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26419,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "可",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9467",
+                    "displayValueParsed": false,
+                    "frequency": 9467,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12633",
+                    "displayValueParsed": false,
+                    "frequency": 12633,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "57887㋕",
+                    "displayValueParsed": false,
+                    "frequency": 57887,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4319,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "科",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6581",
+                    "displayValueParsed": false,
+                    "frequency": 6581,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8555",
+                    "displayValueParsed": false,
+                    "frequency": 8555,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3512,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 152614,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "蚊",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12258",
+                    "displayValueParsed": false,
+                    "frequency": 12258,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12952",
+                    "displayValueParsed": false,
+                    "frequency": 12952,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8283,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "課",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8436",
+                    "displayValueParsed": false,
+                    "frequency": 8436,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6393",
+                    "displayValueParsed": false,
+                    "frequency": 6393,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "69624㋕",
+                    "displayValueParsed": false,
+                    "frequency": 69624,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5002,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "下",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2801",
+                    "displayValueParsed": false,
+                    "frequency": 2801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3986",
+                    "displayValueParsed": false,
+                    "frequency": 3986,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2971,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 105800,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "佳",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "36202",
+                    "displayValueParsed": false,
+                    "frequency": 36202,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47931",
+                    "displayValueParsed": false,
+                    "frequency": 47931,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "価",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "73601",
+                    "displayValueParsed": false,
+                    "frequency": 73601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47025",
+                    "displayValueParsed": false,
+                    "frequency": 47025,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 21934,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 153400,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "化",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2672",
+                    "displayValueParsed": false,
+                    "frequency": 2672,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2336",
+                    "displayValueParsed": false,
+                    "frequency": 2336,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 761,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夏",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "58901",
+                    "displayValueParsed": false,
+                    "frequency": 58901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "164018",
+                    "displayValueParsed": false,
+                    "frequency": 164018,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 28065,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "家",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3313",
+                    "displayValueParsed": false,
+                    "frequency": 3313,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3876,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 95167,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "寡",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "149762",
+                    "displayValueParsed": false,
+                    "frequency": 149762,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "戈",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "99657",
+                    "displayValueParsed": false,
+                    "frequency": 99657,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "115591",
+                    "displayValueParsed": false,
+                    "frequency": 115591,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 119581,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 141501,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "日",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21101",
+                    "displayValueParsed": false,
+                    "frequency": 21101,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "7733",
+                    "displayValueParsed": false,
+                    "frequency": 7733,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 56,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 76112,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "果",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "19261",
+                    "displayValueParsed": false,
+                    "frequency": 19261,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25313",
+                    "displayValueParsed": false,
+                    "frequency": 25313,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 114501,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "架",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29508",
+                    "displayValueParsed": false,
+                    "frequency": 29508,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "41525",
+                    "displayValueParsed": false,
+                    "frequency": 41525,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46930,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "火",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10501",
+                    "displayValueParsed": false,
+                    "frequency": 10501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13005",
+                    "displayValueParsed": false,
+                    "frequency": 13005,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24360,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 146483,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "禍",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "28455",
+                    "displayValueParsed": false,
+                    "frequency": 28455,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 97819,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 109488,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "箇",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "109501",
+                    "displayValueParsed": false,
+                    "frequency": 109501,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "荷",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "135702",
+                    "displayValueParsed": false,
+                    "frequency": 135702,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "347844",
+                    "displayValueParsed": false,
+                    "frequency": 347844,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ない",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ない",
+                    "reading": "ない",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "ない",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29㋕",
+                    "displayValueParsed": false,
+                    "frequency": 29,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "180101㋕",
+                    "displayValueParsed": false,
+                    "frequency": 180101,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "31㋕",
+                    "displayValueParsed": false,
+                    "frequency": 31,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 17,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "無い",
+                    "reading": "ない",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "ない",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29㋕",
+                    "displayValueParsed": false,
+                    "frequency": 29,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1442",
+                    "displayValueParsed": false,
+                    "frequency": 1442,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "31㋕",
+                    "displayValueParsed": false,
+                    "frequency": 31,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2317",
+                    "displayValueParsed": false,
+                    "frequency": 2317,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 28,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "内",
+                    "reading": "ない",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "ない",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "781",
+                    "displayValueParsed": false,
+                    "frequency": 781,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "180101㋕",
+                    "displayValueParsed": false,
+                    "frequency": 180101,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1401",
+                    "displayValueParsed": false,
+                    "frequency": 1401,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "7119㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7119,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 357,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 149564,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亡い",
+                    "reading": "ない",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "ない",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "30737",
+                    "displayValueParsed": false,
+                    "frequency": 30737,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47880",
+                    "displayValueParsed": false,
+                    "frequency": 47880,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 79471,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "地震",
+                    "reading": "ない",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "ない",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 61837,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "なう",
+                    "reading": "なう",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "なう",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45193㋕",
+                    "displayValueParsed": false,
+                    "frequency": 45193,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "51888㋕",
+                    "displayValueParsed": false,
+                    "frequency": 51888,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54078㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54078,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "55371㋕",
+                    "displayValueParsed": false,
+                    "frequency": 55371,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 51840,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "綯う",
+                    "reading": "なう",
+                    "sources": [
+                      {
+                        "originalText": "ない",
+                        "transformedText": "ない",
+                        "deinflectedText": "なう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54078㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54078,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "103761",
+                    "displayValueParsed": false,
+                    "frequency": 103761,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "53554㋕",
+                    "displayValueParsed": false,
+                    "frequency": 53554,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "124609",
+                    "displayValueParsed": false,
+                    "frequency": 124609,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 43653,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "な",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "26㋕",
+                    "displayValueParsed": false,
+                    "frequency": 26,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 89,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "名",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "664",
+                    "displayValueParsed": false,
+                    "frequency": 664,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "835",
+                    "displayValueParsed": false,
+                    "frequency": 835,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14368㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14368,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1813,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 137968,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "菜",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18106",
+                    "displayValueParsed": false,
+                    "frequency": 18106,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21850",
+                    "displayValueParsed": false,
+                    "frequency": 21850,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22974,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 143251,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "儺",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "84943",
+                    "displayValueParsed": false,
+                    "frequency": 84943,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "108965",
+                    "displayValueParsed": false,
+                    "frequency": 108965,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 130367,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "己",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "汝",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8445",
+                    "displayValueParsed": false,
+                    "frequency": 8445,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "dictionary",
+                    "inflectionRules": [
+                      {
+                        "name": "redirected from な"
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "七",
+                    "reading": "しち",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "七",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3638",
+                    "displayValueParsed": false,
+                    "frequency": 3638,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23782㋕",
+                    "displayValueParsed": false,
+                    "frequency": 23782,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11209,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "dictionary",
+                    "inflectionRules": [
+                      {
+                        "name": "redirected from な"
+                      }
+                    ]
+                  }
+                ],
+                "score": 197,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "七",
+                    "reading": "なな",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "七",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1477",
+                    "displayValueParsed": false,
+                    "frequency": 1477,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "13298㋕",
+                    "displayValueParsed": false,
+                    "frequency": 13298,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4003㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4003,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4828,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "dictionary",
+                    "inflectionRules": [
+                      {
+                        "name": "redirected from な"
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "七",
+                    "reading": "チー",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "七",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "い",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "い",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亥",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47280",
+                    "displayValueParsed": false,
+                    "frequency": 47280,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "56084",
+                    "displayValueParsed": false,
+                    "frequency": 56084,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46249,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伊",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14364",
+                    "displayValueParsed": false,
+                    "frequency": 14364,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30166",
+                    "displayValueParsed": false,
+                    "frequency": 30166,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "位",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4902",
+                    "displayValueParsed": false,
+                    "frequency": 4902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4817",
+                    "displayValueParsed": false,
+                    "frequency": 4817,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 967,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134715,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15864",
+                    "displayValueParsed": false,
+                    "frequency": 15864,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19720",
+                    "displayValueParsed": false,
+                    "frequency": 19720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5024,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胃",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4320",
+                    "displayValueParsed": false,
+                    "frequency": 4320,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4265",
+                    "displayValueParsed": false,
+                    "frequency": 4265,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4335,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 94,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 92,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伍",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "井",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6111",
+                    "displayValueParsed": false,
+                    "frequency": 6111,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19958",
+                    "displayValueParsed": false,
+                    "frequency": 19958,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18798,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "偉",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "42742",
+                    "displayValueParsed": false,
+                    "frequency": 42742,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40683",
+                    "displayValueParsed": false,
+                    "frequency": 40683,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65831㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62518,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夷",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75303",
+                    "displayValueParsed": false,
+                    "frequency": 75303,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 85253,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "委",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "42381",
+                    "displayValueParsed": false,
+                    "frequency": 42381,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23040,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "威",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27002",
+                    "displayValueParsed": false,
+                    "frequency": 27002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36921",
+                    "displayValueParsed": false,
+                    "frequency": 36921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30452,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126695,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45301",
+                    "displayValueParsed": false,
+                    "frequency": 45301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236493",
+                    "displayValueParsed": false,
+                    "frequency": 236493,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "彙",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "105649",
+                    "displayValueParsed": false,
+                    "frequency": 105649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160667",
+                    "displayValueParsed": false,
+                    "frequency": 160667,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "意",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4338",
+                    "displayValueParsed": false,
+                    "frequency": 4338,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4069",
+                    "displayValueParsed": false,
+                    "frequency": 4069,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5912,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "易",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 138689,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "汝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "猪",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "118901",
+                    "displayValueParsed": false,
+                    "frequency": 118901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "異",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14852",
+                    "displayValueParsed": false,
+                    "frequency": 14852,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15812",
+                    "displayValueParsed": false,
+                    "frequency": 15812,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4892,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胆",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145167,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "藺",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "94214",
+                    "displayValueParsed": false,
+                    "frequency": 94214,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "138991",
+                    "displayValueParsed": false,
+                    "frequency": 138991,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 99348,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "衣",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24121,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132574,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豬",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "200568",
+                    "displayValueParsed": false,
+                    "frequency": 200568,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "196521",
+                    "displayValueParsed": false,
+                    "frequency": 196521,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豕",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -6,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "緯",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 96278,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "寝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "堰",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -106,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５０",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -107,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五十",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -108,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五〇",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 121488,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "そう言う",
+              "reading": "そういう"
+            },
+            {
+              "term": "そういう",
+              "reading": "そういう"
+            },
+            {
+              "term": "訳にはいかない",
+              "reading": "わけにはいかない"
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "そう言う",
+              "reading": "そういう",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 253,
+              "displayValue": "253㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "そう言う",
+              "reading": "そういう",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 1465,
+              "displayValue": "1465",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "そう言う",
+              "reading": "そういう",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 398,
+              "displayValue": "398㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "そう言う",
+              "reading": "そういう",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 2319,
+              "displayValue": "2319",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "そういう",
+              "reading": "そういう",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 253,
+              "displayValue": "253㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "そういう",
+              "reading": "そういう",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 398,
+              "displayValue": "398㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "訳にはいかない",
+              "reading": "わけにはいかない",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 1715,
+              "displayValue": "1715㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "訳にはいかない",
+              "reading": "わけにはいかない",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 11293,
+              "displayValue": "11293",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "訳にはいかない",
+              "reading": "わけにはいかない",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 1563,
+              "displayValue": "1563㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "訳にはいかない",
+              "reading": "わけにはいかない",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 15072,
+              "displayValue": "15072",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      }
+    ],
+    "scripts": [
+      {
+        "sha256": "fb64f047eb0494f136bb92311df43c5318873298fe3efad6bfa82e5d531a93e1",
+        "marker": "optionsGetFull",
+        "result": {
+          "profileIndex": 0,
+          "scanLength": 21,
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ],
+          "dictionaryPriorityByName": {
+            "Jitendex.org [2026-03-05]": 0,
+            "日本語文法辞典(全集)": 1,
+            "JPDBv2㋕": 2,
+            "Jiten": 3,
+            "CC100": 4,
+            "実用日本語表現辞典": 5,
+            "NHK": 6,
+            "SubMiner Character Dictionary": 7
+          },
+          "dictionaryFrequencyModeByName": {
+            "JPDBv2㋕": "rank-based",
+            "Jiten": "rank-based"
+          }
+        }
+      },
+      {
+        "sha256": "4131bec5df9538a6745f5f07711f52ab476ab3dad777f5d2eb991ec34924cd48",
+        "marker": "parseText",
+        "result": [
+          {
+            "id": "scan",
+            "source": "scanning-parser",
+            "dictionary": null,
+            "index": 0,
+            "content": [
+              [
+                {
+                  "text": "そういう",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "そう言う",
+                        "reading": "そういう",
+                        "sources": [
+                          {
+                            "originalText": "そういう",
+                            "transformedText": "そういう",
+                            "deinflectedText": "そういう",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "然う言う",
+                        "reading": "そういう",
+                        "sources": [
+                          {
+                            "originalText": "そういう",
+                            "transformedText": "そういう",
+                            "deinflectedText": "そういう",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "訳",
+                  "reading": "わけ",
+                  "headwords": [
+                    [
+                      {
+                        "term": "訳にはいかない",
+                        "reading": "わけにはいかない",
+                        "sources": [
+                          {
+                            "originalText": "訳にはいかない",
+                            "transformedText": "訳にはいかない",
+                            "deinflectedText": "訳にはいかない",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "訳にはいかない",
+                        "reading": "わけにはいかない",
+                        "sources": [
+                          {
+                            "originalText": "訳にはいかない",
+                            "transformedText": "訳にはいかない",
+                            "deinflectedText": "訳にはいかない",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "text": "にはいかない",
+                  "reading": ""
+                }
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "24a9b3e348566d9e04c299513922940dc8e08ed8272ff55bac86270bc889367f",
+        "marker": "termsFind",
+        "result": [
+          {
+            "surface": "そういう",
+            "reading": "そういう",
+            "headword": "そう言う",
+            "headwordReading": "そういう",
+            "startPos": 0,
+            "endPos": 4,
+            "isNameMatch": false,
+            "frequencyRank": 253
+          },
+          {
+            "surface": "訳にはいかない",
+            "reading": "わけにはいかない",
+            "headword": "訳にはいかない",
+            "headwordReading": "わけにはいかない",
+            "startPos": 4,
+            "endPos": 11,
+            "isNameMatch": false,
+            "frequencyRank": 1715,
+            "wordClasses": [
+              "adj-i"
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "d235ef66a5b705014b8b8293e0d122c5a6e3f576a7878173e053c01bf1478d32",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "そう言う",
+            "reading": "そういう",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 253,
+            "displayValue": "253㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "そう言う",
+            "reading": "そういう",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 1465,
+            "displayValue": "1465",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "そう言う",
+            "reading": "そういう",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 398,
+            "displayValue": "398㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "そう言う",
+            "reading": "そういう",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 2319,
+            "displayValue": "2319",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "そういう",
+            "reading": "そういう",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 253,
+            "displayValue": "253㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "そういう",
+            "reading": "そういう",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 398,
+            "displayValue": "398㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "訳にはいかない",
+            "reading": "わけにはいかない",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 1715,
+            "displayValue": "1715㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "訳にはいかない",
+            "reading": "わけにはいかない",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 11293,
+            "displayValue": "11293",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "訳にはいかない",
+            "reading": "わけにはいかない",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 1563,
+            "displayValue": "1563㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "訳にはいかない",
+            "reading": "わけにはいかない",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 15072,
+            "displayValue": "15072",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      }
+    ],
+    "mecab": {
+      "そういう訳にはいかない": [
+        {
+          "word": "そういう",
+          "partOfSpeech": "other",
+          "pos1": "連体詞",
+          "pos2": "*",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "そういう",
+          "katakanaReading": "ソウイウ",
+          "pronunciation": "ソーユウ"
+        },
+        {
+          "word": "訳",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "非自立",
+          "pos3": "一般",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "訳",
+          "katakanaReading": "ワケ",
+          "pronunciation": "ワケ"
+        },
+        {
+          "word": "に",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "格助詞",
+          "pos3": "一般",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "に",
+          "katakanaReading": "ニ",
+          "pronunciation": "ニ"
+        },
+        {
+          "word": "は",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "係助詞",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "は",
+          "katakanaReading": "ハ",
+          "pronunciation": "ワ"
+        },
+        {
+          "word": "いか",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "五段・カ行促音便",
+          "inflectionForm": "未然形",
+          "headword": "いく",
+          "katakanaReading": "イカ",
+          "pronunciation": "イカ"
+        },
+        {
+          "word": "ない",
+          "partOfSpeech": "bound_auxiliary",
+          "pos1": "助動詞",
+          "pos2": "*",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "特殊・ナイ",
+          "inflectionForm": "基本形",
+          "headword": "ない",
+          "katakanaReading": "ナイ",
+          "pronunciation": "ナイ"
+        }
+      ]
+    }
+  },
+  "expected": {
+    "tokens": [
+      {
+        "surface": "そういう",
+        "reading": "そういう",
+        "headword": "そう言う",
+        "startPos": 0,
+        "endPos": 4,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "そういう",
+        "pos1": "連体詞",
+        "pos2": "*",
+        "pos3": "*"
+      },
+      {
+        "surface": "訳にはいかない",
+        "reading": "わけにはいかない",
+        "headword": "訳にはいかない",
+        "startPos": 4,
+        "endPos": 11,
+        "partOfSpeech": "i_adjective",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "わけにはいかない",
+        "pos1": "形容詞",
+        "pos2": "非自立|格助詞|係助詞|自立",
+        "pos3": "一般|*",
+        "frequencyRank": 1715
+      }
+    ]
+  }
+}

--- a/src/core/services/tokenizer/__fixtures__/golden/known-word-reading-collision.json
+++ b/src/core/services/tokenizer/__fixtures__/golden/known-word-reading-collision.json
@@ -1,0 +1,11759 @@
+{
+  "name": "known-word-reading-collision",
+  "description": "grammar iru must not borrow known-word highlight from homophonous known iru (needs)",
+  "issueRefs": [
+    "#147"
+  ],
+  "recordedAt": "2026-07-11T00:50:03.809Z",
+  "input": {
+    "text": "ここにいるよ"
+  },
+  "config": {
+    "knownWords": [
+      {
+        "text": "要る",
+        "reading": "いる"
+      }
+    ]
+  },
+  "recording": {
+    "messages": [
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "parseText",
+        "params": {
+          "text": "ここにいるよ",
+          "optionsContext": {
+            "index": 0
+          },
+          "scanLength": 21,
+          "useInternalParser": true,
+          "useMecabParser": false
+        },
+        "response": {
+          "result": [
+            {
+              "id": "scan",
+              "source": "scanning-parser",
+              "dictionary": null,
+              "index": 0,
+              "content": [
+                [
+                  {
+                    "text": "ここに",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "ここに",
+                          "reading": "ここに",
+                          "sources": [
+                            {
+                              "originalText": "ここに",
+                              "transformedText": "ここに",
+                              "deinflectedText": "ここに",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "個々に",
+                          "reading": "ここに",
+                          "sources": [
+                            {
+                              "originalText": "ここに",
+                              "transformedText": "ここに",
+                              "deinflectedText": "ここに",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "個個に",
+                          "reading": "ここに",
+                          "sources": [
+                            {
+                              "originalText": "ここに",
+                              "transformedText": "ここに",
+                              "deinflectedText": "ここに",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "此処に",
+                          "reading": "ここに",
+                          "sources": [
+                            {
+                              "originalText": "ここに",
+                              "transformedText": "ここに",
+                              "deinflectedText": "ここに",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "是に",
+                          "reading": "ここに",
+                          "sources": [
+                            {
+                              "originalText": "ここに",
+                              "transformedText": "ここに",
+                              "deinflectedText": "ここに",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "茲に",
+                          "reading": "ここに",
+                          "sources": [
+                            {
+                              "originalText": "ここに",
+                              "transformedText": "ここに",
+                              "deinflectedText": "ここに",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "爰に",
+                          "reading": "ここに",
+                          "sources": [
+                            {
+                              "originalText": "ここに",
+                              "transformedText": "ここに",
+                              "deinflectedText": "ここに",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "いる",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "いる",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "入る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "射る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "炒る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "要る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "鋳る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "煎る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "沃る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "没る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "率る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "癒る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "将る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "居る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "鑄る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "熬る",
+                          "reading": "いる",
+                          "sources": [
+                            {
+                              "originalText": "いる",
+                              "transformedText": "いる",
+                              "deinflectedText": "いる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "よ",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "よ",
+                          "reading": "よ",
+                          "sources": [
+                            {
+                              "originalText": "よ",
+                              "transformedText": "よ",
+                              "deinflectedText": "よ",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "世",
+                          "reading": "よ",
+                          "sources": [
+                            {
+                              "originalText": "よ",
+                              "transformedText": "よ",
+                              "deinflectedText": "よ",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "代",
+                          "reading": "よ",
+                          "sources": [
+                            {
+                              "originalText": "よ",
+                              "transformedText": "よ",
+                              "deinflectedText": "よ",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "夜",
+                          "reading": "よ",
+                          "sources": [
+                            {
+                              "originalText": "よ",
+                              "transformedText": "よ",
+                              "deinflectedText": "よ",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "四",
+                          "reading": "よ",
+                          "sources": [
+                            {
+                              "originalText": "よ",
+                              "transformedText": "よ",
+                              "deinflectedText": "よ",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "予",
+                          "reading": "よ",
+                          "sources": [
+                            {
+                              "originalText": "よ",
+                              "transformedText": "よ",
+                              "deinflectedText": "よ",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "余",
+                          "reading": "よ",
+                          "sources": [
+                            {
+                              "originalText": "よ",
+                              "transformedText": "よ",
+                              "deinflectedText": "よ",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "節",
+                          "reading": "よ",
+                          "sources": [
+                            {
+                              "originalText": "よ",
+                              "transformedText": "よ",
+                              "deinflectedText": "よ",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "弥",
+                          "reading": "よ",
+                          "sources": [
+                            {
+                              "originalText": "よ",
+                              "transformedText": "よ",
+                              "deinflectedText": "よ",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "餘",
+                          "reading": "よ",
+                          "sources": [
+                            {
+                              "originalText": "よ",
+                              "transformedText": "よ",
+                              "deinflectedText": "よ",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "ヨ",
+                          "reading": "ヨ",
+                          "sources": [
+                            {
+                              "originalText": "よ",
+                              "transformedText": "ヨ",
+                              "deinflectedText": "ヨ",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ここにいるよ",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ここに",
+                    "reading": "ここに",
+                    "sources": [
+                      {
+                        "originalText": "ここに",
+                        "transformedText": "ここに",
+                        "deinflectedText": "ここに",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "54100㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54100,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "個々に",
+                    "reading": "ここに",
+                    "sources": [
+                      {
+                        "originalText": "ここに",
+                        "transformedText": "ここに",
+                        "deinflectedText": "ここに",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "39771",
+                    "displayValueParsed": false,
+                    "frequency": 39771,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "60641",
+                    "displayValueParsed": false,
+                    "frequency": 60641,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "個個に",
+                    "reading": "ここに",
+                    "sources": [
+                      {
+                        "originalText": "ここに",
+                        "transformedText": "ここに",
+                        "deinflectedText": "ここに",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "297389",
+                    "displayValueParsed": false,
+                    "frequency": 297389,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "此処に",
+                    "reading": "ここに",
+                    "sources": [
+                      {
+                        "originalText": "ここに",
+                        "transformedText": "ここに",
+                        "deinflectedText": "ここに",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "54100㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54100,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "81750",
+                    "displayValueParsed": false,
+                    "frequency": 81750,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "是に",
+                    "reading": "ここに",
+                    "sources": [
+                      {
+                        "originalText": "ここに",
+                        "transformedText": "ここに",
+                        "deinflectedText": "ここに",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "54100㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54100,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "茲に",
+                    "reading": "ここに",
+                    "sources": [
+                      {
+                        "originalText": "ここに",
+                        "transformedText": "ここに",
+                        "deinflectedText": "ここに",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "54100㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54100,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "220874",
+                    "displayValueParsed": false,
+                    "frequency": 220874,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -104,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "爰に",
+                    "reading": "ここに",
+                    "sources": [
+                      {
+                        "originalText": "ここに",
+                        "transformedText": "ここに",
+                        "deinflectedText": "ここに",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "54100㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54100,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ここ",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "56㋕",
+                    "displayValueParsed": false,
+                    "frequency": 56,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "201401㋕",
+                    "displayValueParsed": false,
+                    "frequency": 201401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "48㋕",
+                    "displayValueParsed": false,
+                    "frequency": 48,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 444,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "個々",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12321",
+                    "displayValueParsed": false,
+                    "frequency": 12321,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "201401㋕",
+                    "displayValueParsed": false,
+                    "frequency": 201401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10762㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10762,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13860",
+                    "displayValueParsed": false,
+                    "frequency": 13860,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3644,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "個個",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "201401㋕",
+                    "displayValueParsed": false,
+                    "frequency": 201401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "209891",
+                    "displayValueParsed": false,
+                    "frequency": 209891,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10762㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10762,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "141891",
+                    "displayValueParsed": false,
+                    "frequency": 141891,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 119283,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 98,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "箇々",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "101148",
+                    "displayValueParsed": false,
+                    "frequency": 101148,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "201401㋕",
+                    "displayValueParsed": false,
+                    "frequency": 201401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10762㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10762,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "237562",
+                    "displayValueParsed": false,
+                    "frequency": 237562,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 152801,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 97,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "箇箇",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "201401㋕",
+                    "displayValueParsed": false,
+                    "frequency": 201401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "252292",
+                    "displayValueParsed": false,
+                    "frequency": 252292,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10762㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10762,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 88,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "九",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "73937㋕",
+                    "displayValueParsed": false,
+                    "frequency": 73937,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 87,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "９",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "73937㋕",
+                    "displayValueParsed": false,
+                    "frequency": 73937,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 86,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "玖",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "73937㋕",
+                    "displayValueParsed": false,
+                    "frequency": 73937,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "呱々",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "143759",
+                    "displayValueParsed": false,
+                    "frequency": 143759,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236571",
+                    "displayValueParsed": false,
+                    "frequency": 236571,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132357,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "戸戸",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "192393",
+                    "displayValueParsed": false,
+                    "frequency": 192393,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "呱呱",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "255052",
+                    "displayValueParsed": false,
+                    "frequency": 255052,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "戸々",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "201884",
+                    "displayValueParsed": false,
+                    "frequency": 201884,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "229127",
+                    "displayValueParsed": false,
+                    "frequency": 229127,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 123854,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "此処",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "56㋕",
+                    "displayValueParsed": false,
+                    "frequency": 56,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10545",
+                    "displayValueParsed": false,
+                    "frequency": 10545,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "48㋕",
+                    "displayValueParsed": false,
+                    "frequency": 48,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3534",
+                    "displayValueParsed": false,
+                    "frequency": 3534,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 194,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "此所",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "56㋕",
+                    "displayValueParsed": false,
+                    "frequency": 56,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "93513",
+                    "displayValueParsed": false,
+                    "frequency": 93513,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "48㋕",
+                    "displayValueParsed": false,
+                    "frequency": 48,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "117727",
+                    "displayValueParsed": false,
+                    "frequency": 117727,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "是",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "56㋕",
+                    "displayValueParsed": false,
+                    "frequency": 56,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "232401",
+                    "displayValueParsed": false,
+                    "frequency": 232401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 157668,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -104,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "茲",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "56㋕",
+                    "displayValueParsed": false,
+                    "frequency": 56,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "49979",
+                    "displayValueParsed": false,
+                    "frequency": 49979,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "48㋕",
+                    "displayValueParsed": false,
+                    "frequency": 48,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "91366",
+                    "displayValueParsed": false,
+                    "frequency": 91366,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 109858,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -105,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "爰",
+                    "reading": "ここ",
+                    "sources": [
+                      {
+                        "originalText": "ここ",
+                        "transformedText": "ここ",
+                        "deinflectedText": "ここ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "56㋕",
+                    "displayValueParsed": false,
+                    "frequency": 56,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "89287",
+                    "displayValueParsed": false,
+                    "frequency": 89287,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "48㋕",
+                    "displayValueParsed": false,
+                    "frequency": 48,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "150977",
+                    "displayValueParsed": false,
+                    "frequency": 150977,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 157258,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "こ",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1719㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1719,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2686㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2686,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9491,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "個",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2409",
+                    "displayValueParsed": false,
+                    "frequency": 2409,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2177",
+                    "displayValueParsed": false,
+                    "frequency": 2177,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143㋕",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1160,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "子",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "207",
+                    "displayValueParsed": false,
+                    "frequency": 207,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "208",
+                    "displayValueParsed": false,
+                    "frequency": 208,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2686㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2686,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 458,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 103435,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "小",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5902",
+                    "displayValueParsed": false,
+                    "frequency": 5902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12394",
+                    "displayValueParsed": false,
+                    "frequency": 12394,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13568㋕",
+                    "displayValueParsed": false,
+                    "frequency": 13568,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8313,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 141511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "児",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23056",
+                    "displayValueParsed": false,
+                    "frequency": 23056,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2686㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2686,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "41619",
+                    "displayValueParsed": false,
+                    "frequency": 41619,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 142608,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "娘",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150645,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "粉",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 29350,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "仔",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "25543",
+                    "displayValueParsed": false,
+                    "frequency": 25543,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "34109",
+                    "displayValueParsed": false,
+                    "frequency": 34109,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 36761,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "こにいるよ",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "こ",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1719㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1719,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2686㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2686,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9491,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "個",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2409",
+                    "displayValueParsed": false,
+                    "frequency": 2409,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2177",
+                    "displayValueParsed": false,
+                    "frequency": 2177,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143㋕",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1160,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "子",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "207",
+                    "displayValueParsed": false,
+                    "frequency": 207,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "208",
+                    "displayValueParsed": false,
+                    "frequency": 208,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2686㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2686,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 458,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 103435,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "小",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5902",
+                    "displayValueParsed": false,
+                    "frequency": 5902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12394",
+                    "displayValueParsed": false,
+                    "frequency": 12394,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13568㋕",
+                    "displayValueParsed": false,
+                    "frequency": 13568,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8313,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 141511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "児",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23056",
+                    "displayValueParsed": false,
+                    "frequency": 23056,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2686㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2686,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "41619",
+                    "displayValueParsed": false,
+                    "frequency": 41619,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 142608,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "娘",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150645,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "粉",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 29350,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "仔",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "25543",
+                    "displayValueParsed": false,
+                    "frequency": 25543,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "34109",
+                    "displayValueParsed": false,
+                    "frequency": 34109,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 36761,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "壺",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "93202",
+                    "displayValueParsed": false,
+                    "frequency": 93202,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 149854,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "孤",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "31038",
+                    "displayValueParsed": false,
+                    "frequency": 31038,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "39914",
+                    "displayValueParsed": false,
+                    "frequency": 39914,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "200753㋕",
+                    "displayValueParsed": false,
+                    "frequency": 200753,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 47723,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "弧",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "33160",
+                    "displayValueParsed": false,
+                    "frequency": 33160,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "39930",
+                    "displayValueParsed": false,
+                    "frequency": 39930,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30698,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "戸",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27601",
+                    "displayValueParsed": false,
+                    "frequency": 27601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "80664",
+                    "displayValueParsed": false,
+                    "frequency": 80664,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8982,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 116932,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "故",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12048",
+                    "displayValueParsed": false,
+                    "frequency": 12048,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16285",
+                    "displayValueParsed": false,
+                    "frequency": 16285,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 14146,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 135975,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "湖",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11502",
+                    "displayValueParsed": false,
+                    "frequency": 11502,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19394",
+                    "displayValueParsed": false,
+                    "frequency": 19394,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6490,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 153434,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "滬",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "177535",
+                    "displayValueParsed": false,
+                    "frequency": 177535,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "173367",
+                    "displayValueParsed": false,
+                    "frequency": 173367,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 105033,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胡",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "39945",
+                    "displayValueParsed": false,
+                    "frequency": 39945,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "51769",
+                    "displayValueParsed": false,
+                    "frequency": 51769,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 57018,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "壷",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "198902",
+                    "displayValueParsed": false,
+                    "frequency": 198902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "200753",
+                    "displayValueParsed": false,
+                    "frequency": 200753,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 159166,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "濃",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 136177,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "箇",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "39851",
+                    "displayValueParsed": false,
+                    "frequency": 39851,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "82728",
+                    "displayValueParsed": false,
+                    "frequency": 82728,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143㋕",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "海鼠",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "木",
+                    "reading": "こ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "こ",
+                        "deinflectedText": "こ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 108231,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 98,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "コ",
+                    "reading": "コ",
+                    "sources": [
+                      {
+                        "originalText": "こ",
+                        "transformedText": "コ",
+                        "deinflectedText": "コ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9181㋕",
+                    "displayValueParsed": false,
+                    "frequency": 9181,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "49200㋕",
+                    "displayValueParsed": false,
+                    "frequency": 49200,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "169973㋕",
+                    "displayValueParsed": false,
+                    "frequency": 169973,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "316878㋕",
+                    "displayValueParsed": false,
+                    "frequency": 316878,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11119㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11119,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "にいるよ",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "二位",
+                    "reading": "にい",
+                    "sources": [
+                      {
+                        "originalText": "にい",
+                        "transformedText": "にい",
+                        "deinflectedText": "にい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "19453",
+                    "displayValueParsed": false,
+                    "frequency": 19453,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "118004㋕",
+                    "displayValueParsed": false,
+                    "frequency": 118004,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21992㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21992,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "27023",
+                    "displayValueParsed": false,
+                    "frequency": 27023,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 45335,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "二尉",
+                    "reading": "にい",
+                    "sources": [
+                      {
+                        "originalText": "にい",
+                        "transformedText": "にい",
+                        "deinflectedText": "にい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "86783",
+                    "displayValueParsed": false,
+                    "frequency": 86783,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "106014",
+                    "displayValueParsed": false,
+                    "frequency": 106014,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 115428,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "兄",
+                    "reading": "にい",
+                    "sources": [
+                      {
+                        "originalText": "にい",
+                        "transformedText": "にい",
+                        "deinflectedText": "にい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24096㋕",
+                    "displayValueParsed": false,
+                    "frequency": 24096,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "52802",
+                    "displayValueParsed": false,
+                    "frequency": 52802,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 17374,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 152161,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "２位",
+                    "reading": "にい",
+                    "sources": [
+                      {
+                        "originalText": "にい",
+                        "transformedText": "にい",
+                        "deinflectedText": "にい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "17199",
+                    "displayValueParsed": false,
+                    "frequency": 17199,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "118004㋕",
+                    "displayValueParsed": false,
+                    "frequency": 118004,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14608",
+                    "displayValueParsed": false,
+                    "frequency": 14608,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21992㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21992,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "２尉",
+                    "reading": "にい",
+                    "sources": [
+                      {
+                        "originalText": "にい",
+                        "transformedText": "にい",
+                        "deinflectedText": "にい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "146330",
+                    "displayValueParsed": false,
+                    "frequency": 146330,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "161355",
+                    "displayValueParsed": false,
+                    "frequency": 161355,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 143988,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -3,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "新",
+                    "reading": "にい",
+                    "sources": [
+                      {
+                        "originalText": "にい",
+                        "transformedText": "にい",
+                        "deinflectedText": "にい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14091㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14091,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 137089,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "に",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "二",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "532",
+                    "displayValueParsed": false,
+                    "frequency": 532,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1248",
+                    "displayValueParsed": false,
+                    "frequency": 1248,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 409,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 146150,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "荷",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9741",
+                    "displayValueParsed": false,
+                    "frequency": 9741,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12347",
+                    "displayValueParsed": false,
+                    "frequency": 12347,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "93107㋕",
+                    "displayValueParsed": false,
+                    "frequency": 93107,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16472,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "２",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6080",
+                    "displayValueParsed": false,
+                    "frequency": 6080,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "185002",
+                    "displayValueParsed": false,
+                    "frequency": 185002,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 98,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "弐",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27603",
+                    "displayValueParsed": false,
+                    "frequency": 27603,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "33961",
+                    "displayValueParsed": false,
+                    "frequency": 33961,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 45426,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 97,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "弍",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "176149",
+                    "displayValueParsed": false,
+                    "frequency": 176149,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236571",
+                    "displayValueParsed": false,
+                    "frequency": 236571,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 95,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "貮",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "213932",
+                    "displayValueParsed": false,
+                    "frequency": 213932,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "253770",
+                    "displayValueParsed": false,
+                    "frequency": 253770,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "丹",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23215",
+                    "displayValueParsed": false,
+                    "frequency": 23215,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "38056",
+                    "displayValueParsed": false,
+                    "frequency": 38056,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 47796,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 133516,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "似",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15588",
+                    "displayValueParsed": false,
+                    "frequency": 15588,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "18831",
+                    "displayValueParsed": false,
+                    "frequency": 18831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 20085,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "土",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 112427,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "尼",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24925",
+                    "displayValueParsed": false,
+                    "frequency": 24925,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "39335",
+                    "displayValueParsed": false,
+                    "frequency": 39335,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26189,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "煮",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21728",
+                    "displayValueParsed": false,
+                    "frequency": 21728,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "32488",
+                    "displayValueParsed": false,
+                    "frequency": 32488,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 20677,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -104,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "貳",
+                    "reading": "に",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "に",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "126258",
+                    "displayValueParsed": false,
+                    "frequency": 126258,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "138327",
+                    "displayValueParsed": false,
+                    "frequency": 138327,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605㋕",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "似る",
+                    "reading": "にる",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "にる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "398",
+                    "displayValueParsed": false,
+                    "frequency": 398,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "41989㋕",
+                    "displayValueParsed": false,
+                    "frequency": 41989,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "508",
+                    "displayValueParsed": false,
+                    "frequency": 508,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11843㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11843,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1135,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 131640,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "煮る",
+                    "reading": "にる",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "にる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9957",
+                    "displayValueParsed": false,
+                    "frequency": 9957,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10606",
+                    "displayValueParsed": false,
+                    "frequency": 10606,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "烹る",
+                    "reading": "にる",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "に",
+                        "deinflectedText": "にる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "135057",
+                    "displayValueParsed": false,
+                    "frequency": 135057,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "141417",
+                    "displayValueParsed": false,
+                    "frequency": 141417,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ニ",
+                    "reading": "ニ",
+                    "sources": [
+                      {
+                        "originalText": "に",
+                        "transformedText": "ニ",
+                        "deinflectedText": "ニ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12999㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12999,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "19284㋕",
+                    "displayValueParsed": false,
+                    "frequency": 19284,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "274744㋕",
+                    "displayValueParsed": false,
+                    "frequency": 274744,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26869,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "いるよ",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "いる",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "701㋕",
+                    "displayValueParsed": false,
+                    "frequency": 701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "37㋕",
+                    "displayValueParsed": false,
+                    "frequency": 37,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "入る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7401",
+                    "displayValueParsed": false,
+                    "frequency": 7401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "57360",
+                    "displayValueParsed": false,
+                    "frequency": 57360,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "173912㋕",
+                    "displayValueParsed": false,
+                    "frequency": 173912,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22083,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 75676,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "射る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8836",
+                    "displayValueParsed": false,
+                    "frequency": 8836,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15807",
+                    "displayValueParsed": false,
+                    "frequency": 15807,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 19354,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "炒る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54739",
+                    "displayValueParsed": false,
+                    "frequency": 54739,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "63798",
+                    "displayValueParsed": false,
+                    "frequency": 63798,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 21188,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "要る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "701㋕",
+                    "displayValueParsed": false,
+                    "frequency": 701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3812",
+                    "displayValueParsed": false,
+                    "frequency": 3812,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "983㋕",
+                    "displayValueParsed": false,
+                    "frequency": 983,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2982",
+                    "displayValueParsed": false,
+                    "frequency": 2982,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2980,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鋳る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "60104",
+                    "displayValueParsed": false,
+                    "frequency": 60104,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "83416",
+                    "displayValueParsed": false,
+                    "frequency": 83416,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 84432,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "煎る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "61535",
+                    "displayValueParsed": false,
+                    "frequency": 61535,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65367",
+                    "displayValueParsed": false,
+                    "frequency": 65367,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 64561,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "沃る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "122431",
+                    "displayValueParsed": false,
+                    "frequency": 122431,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "没る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "231790",
+                    "displayValueParsed": false,
+                    "frequency": 231790,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "率る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "100203",
+                    "displayValueParsed": false,
+                    "frequency": 100203,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "癒る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23034",
+                    "displayValueParsed": false,
+                    "frequency": 23034,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "43124",
+                    "displayValueParsed": false,
+                    "frequency": 43124,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 127378,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "将る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "212849",
+                    "displayValueParsed": false,
+                    "frequency": 212849,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3021",
+                    "displayValueParsed": false,
+                    "frequency": 3021,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "37㋕",
+                    "displayValueParsed": false,
+                    "frequency": 37,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2172",
+                    "displayValueParsed": false,
+                    "frequency": 2172,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 92231,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鑄る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "255560",
+                    "displayValueParsed": false,
+                    "frequency": 255560,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "206069",
+                    "displayValueParsed": false,
+                    "frequency": 206069,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "熬る",
+                    "reading": "いる",
+                    "sources": [
+                      {
+                        "originalText": "いる",
+                        "transformedText": "いる",
+                        "deinflectedText": "いる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "300815",
+                    "displayValueParsed": false,
+                    "frequency": 300815,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "い",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亥",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47280",
+                    "displayValueParsed": false,
+                    "frequency": 47280,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "56084",
+                    "displayValueParsed": false,
+                    "frequency": 56084,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46249,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伊",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14364",
+                    "displayValueParsed": false,
+                    "frequency": 14364,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30166",
+                    "displayValueParsed": false,
+                    "frequency": 30166,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "位",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4902",
+                    "displayValueParsed": false,
+                    "frequency": 4902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4817",
+                    "displayValueParsed": false,
+                    "frequency": 4817,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 967,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134715,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15864",
+                    "displayValueParsed": false,
+                    "frequency": 15864,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19720",
+                    "displayValueParsed": false,
+                    "frequency": 19720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5024,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胃",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4320",
+                    "displayValueParsed": false,
+                    "frequency": 4320,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4265",
+                    "displayValueParsed": false,
+                    "frequency": 4265,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4335,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 94,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 92,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伍",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "井",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6111",
+                    "displayValueParsed": false,
+                    "frequency": 6111,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19958",
+                    "displayValueParsed": false,
+                    "frequency": 19958,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18798,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "偉",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "42742",
+                    "displayValueParsed": false,
+                    "frequency": 42742,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40683",
+                    "displayValueParsed": false,
+                    "frequency": 40683,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65831㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62518,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夷",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75303",
+                    "displayValueParsed": false,
+                    "frequency": 75303,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 85253,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "委",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "42381",
+                    "displayValueParsed": false,
+                    "frequency": 42381,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23040,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "威",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27002",
+                    "displayValueParsed": false,
+                    "frequency": 27002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36921",
+                    "displayValueParsed": false,
+                    "frequency": 36921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30452,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126695,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45301",
+                    "displayValueParsed": false,
+                    "frequency": 45301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236493",
+                    "displayValueParsed": false,
+                    "frequency": 236493,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "彙",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "105649",
+                    "displayValueParsed": false,
+                    "frequency": 105649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160667",
+                    "displayValueParsed": false,
+                    "frequency": 160667,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "意",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4338",
+                    "displayValueParsed": false,
+                    "frequency": 4338,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4069",
+                    "displayValueParsed": false,
+                    "frequency": 4069,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5912,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "るよ",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "る",
+                    "reading": "る",
+                    "sources": [
+                      {
+                        "originalText": "る",
+                        "transformedText": "る",
+                        "deinflectedText": "る",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 120252,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "流",
+                    "reading": "る",
+                    "sources": [
+                      {
+                        "originalText": "る",
+                        "transformedText": "る",
+                        "deinflectedText": "る",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "22731",
+                    "displayValueParsed": false,
+                    "frequency": 22731,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "よ",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "よ",
+                    "reading": "よ",
+                    "sources": [
+                      {
+                        "originalText": "よ",
+                        "transformedText": "よ",
+                        "deinflectedText": "よ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "13㋕",
+                    "displayValueParsed": false,
+                    "frequency": 13,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13㋕",
+                    "displayValueParsed": false,
+                    "frequency": 13,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 69,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "世",
+                    "reading": "よ",
+                    "sources": [
+                      {
+                        "originalText": "よ",
+                        "transformedText": "よ",
+                        "deinflectedText": "よ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2424",
+                    "displayValueParsed": false,
+                    "frequency": 2424,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2616",
+                    "displayValueParsed": false,
+                    "frequency": 2616,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8553㋕",
+                    "displayValueParsed": false,
+                    "frequency": 8553,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3337,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "代",
+                    "reading": "よ",
+                    "sources": [
+                      {
+                        "originalText": "よ",
+                        "transformedText": "よ",
+                        "deinflectedText": "よ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "116601",
+                    "displayValueParsed": false,
+                    "frequency": 116601,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夜",
+                    "reading": "よ",
+                    "sources": [
+                      {
+                        "originalText": "よ",
+                        "transformedText": "よ",
+                        "deinflectedText": "よ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 54511,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 136010,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 96,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四",
+                    "reading": "よ",
+                    "sources": [
+                      {
+                        "originalText": "よ",
+                        "transformedText": "よ",
+                        "deinflectedText": "よ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40612㋕",
+                    "displayValueParsed": false,
+                    "frequency": 40612,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 17239,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "予",
+                    "reading": "よ",
+                    "sources": [
+                      {
+                        "originalText": "よ",
+                        "transformedText": "よ",
+                        "deinflectedText": "よ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23611",
+                    "displayValueParsed": false,
+                    "frequency": 23611,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23995",
+                    "displayValueParsed": false,
+                    "frequency": 23995,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 42815,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "余",
+                    "reading": "よ",
+                    "sources": [
+                      {
+                        "originalText": "よ",
+                        "transformedText": "よ",
+                        "deinflectedText": "よ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4706",
+                    "displayValueParsed": false,
+                    "frequency": 4706,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11006",
+                    "displayValueParsed": false,
+                    "frequency": 11006,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 13313,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 157493,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "節",
+                    "reading": "よ",
+                    "sources": [
+                      {
+                        "originalText": "よ",
+                        "transformedText": "よ",
+                        "deinflectedText": "よ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 116345,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "弥",
+                    "reading": "よ",
+                    "sources": [
+                      {
+                        "originalText": "よ",
+                        "transformedText": "よ",
+                        "deinflectedText": "よ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 155276,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "餘",
+                    "reading": "よ",
+                    "sources": [
+                      {
+                        "originalText": "よ",
+                        "transformedText": "よ",
+                        "deinflectedText": "よ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "102576",
+                    "displayValueParsed": false,
+                    "frequency": 102576,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "119776",
+                    "displayValueParsed": false,
+                    "frequency": 119776,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 151134,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ヨ",
+                    "reading": "ヨ",
+                    "sources": [
+                      {
+                        "originalText": "よ",
+                        "transformedText": "ヨ",
+                        "deinflectedText": "ヨ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24994㋕",
+                    "displayValueParsed": false,
+                    "frequency": 24994,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "176599㋕",
+                    "displayValueParsed": false,
+                    "frequency": 176599,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36503㋕",
+                    "displayValueParsed": false,
+                    "frequency": 36503,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "ここに",
+              "reading": "ここに"
+            },
+            {
+              "term": "いる",
+              "reading": "いる"
+            },
+            {
+              "term": "よ",
+              "reading": "よ"
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "ここに",
+              "reading": "ここに",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 54100,
+              "displayValue": "54100㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "いる",
+              "reading": "いる",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 18,
+              "displayValue": "18㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "いる",
+              "reading": "いる",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 701,
+              "displayValue": "701㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "いる",
+              "reading": "いる",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 37,
+              "displayValue": "37㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "よ",
+              "reading": "よ",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 13,
+              "displayValue": "13㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "よ",
+              "reading": "よ",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 69,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "よ",
+              "reading": "よ",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 13,
+              "displayValue": "13㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      }
+    ],
+    "scripts": [
+      {
+        "sha256": "fb64f047eb0494f136bb92311df43c5318873298fe3efad6bfa82e5d531a93e1",
+        "marker": "optionsGetFull",
+        "result": {
+          "profileIndex": 0,
+          "scanLength": 21,
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ],
+          "dictionaryPriorityByName": {
+            "Jitendex.org [2026-03-05]": 0,
+            "日本語文法辞典(全集)": 1,
+            "JPDBv2㋕": 2,
+            "Jiten": 3,
+            "CC100": 4,
+            "実用日本語表現辞典": 5,
+            "NHK": 6,
+            "SubMiner Character Dictionary": 7
+          },
+          "dictionaryFrequencyModeByName": {
+            "JPDBv2㋕": "rank-based",
+            "Jiten": "rank-based"
+          }
+        }
+      },
+      {
+        "sha256": "4f4ad8ba3d4a79a6257707bec066b451f01d914191cd6fd278399bb35fe983ff",
+        "marker": "parseText",
+        "result": [
+          {
+            "id": "scan",
+            "source": "scanning-parser",
+            "dictionary": null,
+            "index": 0,
+            "content": [
+              [
+                {
+                  "text": "ここに",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "ここに",
+                        "reading": "ここに",
+                        "sources": [
+                          {
+                            "originalText": "ここに",
+                            "transformedText": "ここに",
+                            "deinflectedText": "ここに",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "個々に",
+                        "reading": "ここに",
+                        "sources": [
+                          {
+                            "originalText": "ここに",
+                            "transformedText": "ここに",
+                            "deinflectedText": "ここに",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "個個に",
+                        "reading": "ここに",
+                        "sources": [
+                          {
+                            "originalText": "ここに",
+                            "transformedText": "ここに",
+                            "deinflectedText": "ここに",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "此処に",
+                        "reading": "ここに",
+                        "sources": [
+                          {
+                            "originalText": "ここに",
+                            "transformedText": "ここに",
+                            "deinflectedText": "ここに",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "是に",
+                        "reading": "ここに",
+                        "sources": [
+                          {
+                            "originalText": "ここに",
+                            "transformedText": "ここに",
+                            "deinflectedText": "ここに",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "茲に",
+                        "reading": "ここに",
+                        "sources": [
+                          {
+                            "originalText": "ここに",
+                            "transformedText": "ここに",
+                            "deinflectedText": "ここに",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "爰に",
+                        "reading": "ここに",
+                        "sources": [
+                          {
+                            "originalText": "ここに",
+                            "transformedText": "ここに",
+                            "deinflectedText": "ここに",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "いる",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "いる",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "入る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "射る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "炒る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "要る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "鋳る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "煎る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "沃る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "没る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "率る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "癒る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "将る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "居る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "鑄る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "熬る",
+                        "reading": "いる",
+                        "sources": [
+                          {
+                            "originalText": "いる",
+                            "transformedText": "いる",
+                            "deinflectedText": "いる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "よ",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "よ",
+                        "reading": "よ",
+                        "sources": [
+                          {
+                            "originalText": "よ",
+                            "transformedText": "よ",
+                            "deinflectedText": "よ",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "世",
+                        "reading": "よ",
+                        "sources": [
+                          {
+                            "originalText": "よ",
+                            "transformedText": "よ",
+                            "deinflectedText": "よ",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "代",
+                        "reading": "よ",
+                        "sources": [
+                          {
+                            "originalText": "よ",
+                            "transformedText": "よ",
+                            "deinflectedText": "よ",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "夜",
+                        "reading": "よ",
+                        "sources": [
+                          {
+                            "originalText": "よ",
+                            "transformedText": "よ",
+                            "deinflectedText": "よ",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "四",
+                        "reading": "よ",
+                        "sources": [
+                          {
+                            "originalText": "よ",
+                            "transformedText": "よ",
+                            "deinflectedText": "よ",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "予",
+                        "reading": "よ",
+                        "sources": [
+                          {
+                            "originalText": "よ",
+                            "transformedText": "よ",
+                            "deinflectedText": "よ",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "余",
+                        "reading": "よ",
+                        "sources": [
+                          {
+                            "originalText": "よ",
+                            "transformedText": "よ",
+                            "deinflectedText": "よ",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "節",
+                        "reading": "よ",
+                        "sources": [
+                          {
+                            "originalText": "よ",
+                            "transformedText": "よ",
+                            "deinflectedText": "よ",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "弥",
+                        "reading": "よ",
+                        "sources": [
+                          {
+                            "originalText": "よ",
+                            "transformedText": "よ",
+                            "deinflectedText": "よ",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "餘",
+                        "reading": "よ",
+                        "sources": [
+                          {
+                            "originalText": "よ",
+                            "transformedText": "よ",
+                            "deinflectedText": "よ",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "ヨ",
+                        "reading": "ヨ",
+                        "sources": [
+                          {
+                            "originalText": "よ",
+                            "transformedText": "ヨ",
+                            "deinflectedText": "ヨ",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "b5a86496916100401025cad485a37314ffa72f9945498b370346fafebdb34626",
+        "marker": "termsFind",
+        "result": [
+          {
+            "surface": "ここに",
+            "reading": "ここに",
+            "headword": "ここに",
+            "headwordReading": "ここに",
+            "startPos": 0,
+            "endPos": 3,
+            "isNameMatch": false,
+            "frequencyRank": 54100
+          },
+          {
+            "surface": "いる",
+            "reading": "いる",
+            "headword": "いる",
+            "headwordReading": "いる",
+            "startPos": 3,
+            "endPos": 5,
+            "isNameMatch": false,
+            "frequencyRank": 18,
+            "wordClasses": [
+              "v1"
+            ]
+          },
+          {
+            "surface": "よ",
+            "reading": "よ",
+            "headword": "よ",
+            "headwordReading": "よ",
+            "startPos": 5,
+            "endPos": 6,
+            "isNameMatch": false,
+            "frequencyRank": 13
+          }
+        ]
+      },
+      {
+        "sha256": "fa05ff9d727f227308cc05689d900f34e35feeff7c743aa4acf090c98e3dd1f3",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "ここに",
+            "reading": "ここに",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 54100,
+            "displayValue": "54100㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "いる",
+            "reading": "いる",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 18,
+            "displayValue": "18㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "いる",
+            "reading": "いる",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 701,
+            "displayValue": "701㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "いる",
+            "reading": "いる",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 37,
+            "displayValue": "37㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "よ",
+            "reading": "よ",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 13,
+            "displayValue": "13㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "よ",
+            "reading": "よ",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 69,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "よ",
+            "reading": "よ",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 13,
+            "displayValue": "13㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      }
+    ],
+    "mecab": {
+      "ここにいるよ": [
+        {
+          "word": "ここ",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "代名詞",
+          "pos3": "一般",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "ここ",
+          "katakanaReading": "ココ",
+          "pronunciation": "ココ"
+        },
+        {
+          "word": "に",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "格助詞",
+          "pos3": "一般",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "に",
+          "katakanaReading": "ニ",
+          "pronunciation": "ニ"
+        },
+        {
+          "word": "いる",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "一段",
+          "inflectionForm": "基本形",
+          "headword": "いる",
+          "katakanaReading": "イル",
+          "pronunciation": "イル"
+        },
+        {
+          "word": "よ",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "終助詞",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "よ",
+          "katakanaReading": "ヨ",
+          "pronunciation": "ヨ"
+        }
+      ]
+    }
+  },
+  "expected": {
+    "tokens": [
+      {
+        "surface": "ここに",
+        "reading": "ここに",
+        "headword": "ここに",
+        "startPos": 0,
+        "endPos": 3,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "ここに",
+        "pos1": "名詞|助詞",
+        "pos2": "代名詞|格助詞",
+        "pos3": "一般",
+        "frequencyRank": 54100
+      },
+      {
+        "surface": "いる",
+        "reading": "いる",
+        "headword": "いる",
+        "startPos": 3,
+        "endPos": 5,
+        "partOfSpeech": "verb",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "いる",
+        "pos1": "動詞",
+        "pos2": "自立",
+        "pos3": "*",
+        "frequencyRank": 18
+      },
+      {
+        "surface": "よ",
+        "reading": "よ",
+        "headword": "よ",
+        "startPos": 5,
+        "endPos": 6,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "よ",
+        "pos1": "助詞",
+        "pos2": "終助詞",
+        "pos3": "*"
+      }
+    ]
+  }
+}

--- a/src/core/services/tokenizer/__fixtures__/golden/kureru-lexical-keep.json
+++ b/src/core/services/tokenizer/__fixtures__/golden/kureru-lexical-keep.json
@@ -1,0 +1,13085 @@
+{
+  "name": "kureru-lexical-keep",
+  "description": "lexical kureru in benefactive keeps its annotation instead of being suppressed as auxiliary",
+  "issueRefs": [
+    "#153"
+  ],
+  "recordedAt": "2026-07-11T00:49:37.915Z",
+  "input": {
+    "text": "手伝ってくれてありがとう"
+  },
+  "config": {},
+  "recording": {
+    "messages": [
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "parseText",
+        "params": {
+          "text": "手伝ってくれてありがとう",
+          "optionsContext": {
+            "index": 0
+          },
+          "scanLength": 21,
+          "useInternalParser": true,
+          "useMecabParser": false
+        },
+        "response": {
+          "result": [
+            {
+              "id": "scan",
+              "source": "scanning-parser",
+              "dictionary": null,
+              "index": 0,
+              "content": [
+                [
+                  {
+                    "text": "手伝",
+                    "reading": "てつだ",
+                    "headwords": [
+                      [
+                        {
+                          "term": "手伝う",
+                          "reading": "てつだう",
+                          "sources": [
+                            {
+                              "originalText": "手伝って",
+                              "transformedText": "手伝って",
+                              "deinflectedText": "手伝う",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "text": "って",
+                    "reading": ""
+                  }
+                ],
+                [
+                  {
+                    "text": "くれて",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "呉れ手",
+                          "reading": "くれて",
+                          "sources": [
+                            {
+                              "originalText": "くれて",
+                              "transformedText": "くれて",
+                              "deinflectedText": "くれて",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "くれる",
+                          "reading": "くれる",
+                          "sources": [
+                            {
+                              "originalText": "くれて",
+                              "transformedText": "くれて",
+                              "deinflectedText": "くれる",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "暮れる",
+                          "reading": "くれる",
+                          "sources": [
+                            {
+                              "originalText": "くれて",
+                              "transformedText": "くれて",
+                              "deinflectedText": "くれる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "呉れる",
+                          "reading": "くれる",
+                          "sources": [
+                            {
+                              "originalText": "くれて",
+                              "transformedText": "くれて",
+                              "deinflectedText": "くれる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "昏れる",
+                          "reading": "くれる",
+                          "sources": [
+                            {
+                              "originalText": "くれて",
+                              "transformedText": "くれて",
+                              "deinflectedText": "くれる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "眩れる",
+                          "reading": "くれる",
+                          "sources": [
+                            {
+                              "originalText": "くれて",
+                              "transformedText": "くれて",
+                              "deinflectedText": "くれる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "暗れる",
+                          "reading": "くれる",
+                          "sources": [
+                            {
+                              "originalText": "くれて",
+                              "transformedText": "くれて",
+                              "deinflectedText": "くれる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "昏れる",
+                          "reading": "くれる",
+                          "sources": [
+                            {
+                              "originalText": "くれて",
+                              "transformedText": "くれて",
+                              "deinflectedText": "くれる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "暮れる",
+                          "reading": "くれる",
+                          "sources": [
+                            {
+                              "originalText": "くれて",
+                              "transformedText": "くれて",
+                              "deinflectedText": "くれる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "繰る",
+                          "reading": "くる",
+                          "sources": [
+                            {
+                              "originalText": "くれて",
+                              "transformedText": "くれて",
+                              "deinflectedText": "くる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "刳る",
+                          "reading": "くる",
+                          "sources": [
+                            {
+                              "originalText": "くれて",
+                              "transformedText": "くれて",
+                              "deinflectedText": "くる",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "ありがとう",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "ありがとう",
+                          "reading": "ありがとう",
+                          "sources": [
+                            {
+                              "originalText": "ありがとう",
+                              "transformedText": "ありがとう",
+                              "deinflectedText": "ありがとう",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "有難う",
+                          "reading": "ありがとう",
+                          "sources": [
+                            {
+                              "originalText": "ありがとう",
+                              "transformedText": "ありがとう",
+                              "deinflectedText": "ありがとう",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "有り難う",
+                          "reading": "ありがとう",
+                          "sources": [
+                            {
+                              "originalText": "ありがとう",
+                              "transformedText": "ありがとう",
+                              "deinflectedText": "ありがとう",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "有難い",
+                          "reading": "ありがたい",
+                          "sources": [
+                            {
+                              "originalText": "ありがとう",
+                              "transformedText": "ありがとう",
+                              "deinflectedText": "ありがたい",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "有り難い",
+                          "reading": "ありがたい",
+                          "sources": [
+                            {
+                              "originalText": "ありがとう",
+                              "transformedText": "ありがとう",
+                              "deinflectedText": "ありがたい",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "手伝ってくれてありがとう",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "手伝う",
+                    "reading": "てつだう",
+                    "sources": [
+                      {
+                        "originalText": "手伝って",
+                        "transformedText": "手伝って",
+                        "deinflectedText": "手伝う",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "854",
+                    "displayValueParsed": false,
+                    "frequency": 854,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "59676㋕",
+                    "displayValueParsed": false,
+                    "frequency": 59676,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "563",
+                    "displayValueParsed": false,
+                    "frequency": 563,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "48110㋕",
+                    "displayValueParsed": false,
+                    "frequency": 48110,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3985,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "手",
+                    "reading": "て",
+                    "sources": [
+                      {
+                        "originalText": "手",
+                        "transformedText": "手",
+                        "deinflectedText": "手",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "114",
+                    "displayValueParsed": false,
+                    "frequency": 114,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "154",
+                    "displayValueParsed": false,
+                    "frequency": 154,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12492㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12492,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 200,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 122414,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 4
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "伝ってくれてありがとう",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伝う",
+                    "reading": "つたう",
+                    "sources": [
+                      {
+                        "originalText": "伝って",
+                        "transformedText": "伝って",
+                        "deinflectedText": "伝う",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4167",
+                    "displayValueParsed": false,
+                    "frequency": 4167,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22095㋕",
+                    "displayValueParsed": false,
+                    "frequency": 22095,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5812",
+                    "displayValueParsed": false,
+                    "frequency": 5812,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "26481㋕",
+                    "displayValueParsed": false,
+                    "frequency": 26481,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24584,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伝",
+                    "reading": "つて",
+                    "sources": [
+                      {
+                        "originalText": "伝",
+                        "transformedText": "伝",
+                        "deinflectedText": "伝",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15596㋕",
+                    "displayValueParsed": false,
+                    "frequency": 15596,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "39401",
+                    "displayValueParsed": false,
+                    "frequency": 39401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6719㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6719,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "22181",
+                    "displayValueParsed": false,
+                    "frequency": 22181,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23095,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134583,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伝",
+                    "reading": "でん",
+                    "sources": [
+                      {
+                        "originalText": "伝",
+                        "transformedText": "伝",
+                        "deinflectedText": "伝",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12238",
+                    "displayValueParsed": false,
+                    "frequency": 12238,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "216697㋕",
+                    "displayValueParsed": false,
+                    "frequency": 216697,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11666㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11666,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "22112",
+                    "displayValueParsed": false,
+                    "frequency": 22112,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10901,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134583,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ってくれてありがとう",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "って",
+                    "reading": "って",
+                    "sources": [
+                      {
+                        "originalText": "って",
+                        "transformedText": "って",
+                        "deinflectedText": "って",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "28㋕",
+                    "displayValueParsed": false,
+                    "frequency": 28,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25㋕",
+                    "displayValueParsed": false,
+                    "frequency": 25,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 106,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "てくれてありがとう",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "てく",
+                    "reading": "てく",
+                    "sources": [
+                      {
+                        "originalText": "てく",
+                        "transformedText": "てく",
+                        "deinflectedText": "てく",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5937㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5937,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4276,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "テク",
+                    "reading": "テク",
+                    "sources": [
+                      {
+                        "originalText": "てく",
+                        "transformedText": "テク",
+                        "deinflectedText": "テク",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29638㋕",
+                    "displayValueParsed": false,
+                    "frequency": 29638,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15049㋕",
+                    "displayValueParsed": false,
+                    "frequency": 15049,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18832,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 199,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "て",
+                    "reading": "て",
+                    "sources": [
+                      {
+                        "originalText": "て",
+                        "transformedText": "て",
+                        "deinflectedText": "て",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      },
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "159㋕",
+                    "displayValueParsed": false,
+                    "frequency": 159,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "450㋕",
+                    "displayValueParsed": false,
+                    "frequency": 450,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "手",
+                    "reading": "て",
+                    "sources": [
+                      {
+                        "originalText": "て",
+                        "transformedText": "て",
+                        "deinflectedText": "て",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "114",
+                    "displayValueParsed": false,
+                    "frequency": 114,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "154",
+                    "displayValueParsed": false,
+                    "frequency": 154,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12492㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12492,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 200,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 122414,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "てる",
+                    "reading": "てる",
+                    "sources": [
+                      {
+                        "originalText": "て",
+                        "transformedText": "て",
+                        "deinflectedText": "てる",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1580㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1580,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "57901㋕",
+                    "displayValueParsed": false,
+                    "frequency": 57901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1094㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1094,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 54,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "くれてありがとう",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "呉れ手",
+                    "reading": "くれて",
+                    "sources": [
+                      {
+                        "originalText": "くれて",
+                        "transformedText": "くれて",
+                        "deinflectedText": "くれて",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 128337,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "くれる",
+                    "reading": "くれる",
+                    "sources": [
+                      {
+                        "originalText": "くれて",
+                        "transformedText": "くれて",
+                        "deinflectedText": "くれる",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "40㋕",
+                    "displayValueParsed": false,
+                    "frequency": 40,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "66301㋕",
+                    "displayValueParsed": false,
+                    "frequency": 66301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "507㋕",
+                    "displayValueParsed": false,
+                    "frequency": 507,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 219,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "暮れる",
+                    "reading": "くれる",
+                    "sources": [
+                      {
+                        "originalText": "くれて",
+                        "transformedText": "くれて",
+                        "deinflectedText": "くれる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7745",
+                    "displayValueParsed": false,
+                    "frequency": 7745,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "66301㋕",
+                    "displayValueParsed": false,
+                    "frequency": 66301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2876㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2876,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "9152",
+                    "displayValueParsed": false,
+                    "frequency": 9152,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8222,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "昏れる",
+                    "reading": "くれる",
+                    "sources": [
+                      {
+                        "originalText": "くれて",
+                        "transformedText": "くれて",
+                        "deinflectedText": "くれる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "66301㋕",
+                    "displayValueParsed": false,
+                    "frequency": 66301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "98152",
+                    "displayValueParsed": false,
+                    "frequency": 98152,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2876㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2876,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "158071",
+                    "displayValueParsed": false,
+                    "frequency": 158071,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "呉れる",
+                    "reading": "くれる",
+                    "sources": [
+                      {
+                        "originalText": "くれて",
+                        "transformedText": "くれて",
+                        "deinflectedText": "くれる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "40㋕",
+                    "displayValueParsed": false,
+                    "frequency": 40,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "30172",
+                    "displayValueParsed": false,
+                    "frequency": 30172,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "507㋕",
+                    "displayValueParsed": false,
+                    "frequency": 507,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "35365",
+                    "displayValueParsed": false,
+                    "frequency": 35365,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 109,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "眩れる",
+                    "reading": "くれる",
+                    "sources": [
+                      {
+                        "originalText": "くれて",
+                        "transformedText": "くれて",
+                        "deinflectedText": "くれる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "66301㋕",
+                    "displayValueParsed": false,
+                    "frequency": 66301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "256417",
+                    "displayValueParsed": false,
+                    "frequency": 256417,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2876㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2876,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "235284",
+                    "displayValueParsed": false,
+                    "frequency": 235284,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "暗れる",
+                    "reading": "くれる",
+                    "sources": [
+                      {
+                        "originalText": "くれて",
+                        "transformedText": "くれて",
+                        "deinflectedText": "くれる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "66301㋕",
+                    "displayValueParsed": false,
+                    "frequency": 66301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "273122",
+                    "displayValueParsed": false,
+                    "frequency": 273122,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2876㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2876,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "189653",
+                    "displayValueParsed": false,
+                    "frequency": 189653,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "potential",
+                        "description": "Indicates a state of being (naturally) capable of doing an action.\nUsage: Attach (ら)れる to the irrealis form (未然形) of ichidan verbs.\nAttach る to the imperative form (命令形) of godan verbs.\nする becomes できる, くる becomes こ(ら)れる"
+                      },
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "繰る",
+                    "reading": "くる",
+                    "sources": [
+                      {
+                        "originalText": "くれて",
+                        "transformedText": "くれて",
+                        "deinflectedText": "くる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15253",
+                    "displayValueParsed": false,
+                    "frequency": 15253,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "83601㋕",
+                    "displayValueParsed": false,
+                    "frequency": 83601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "22320",
+                    "displayValueParsed": false,
+                    "frequency": 22320,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30711㋕",
+                    "displayValueParsed": false,
+                    "frequency": 30711,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27213,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "potential",
+                        "description": "Indicates a state of being (naturally) capable of doing an action.\nUsage: Attach (ら)れる to the irrealis form (未然形) of ichidan verbs.\nAttach る to the imperative form (命令形) of godan verbs.\nする becomes できる, くる becomes こ(ら)れる"
+                      },
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": -3,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "刳る",
+                    "reading": "くる",
+                    "sources": [
+                      {
+                        "originalText": "くれて",
+                        "transformedText": "くれて",
+                        "deinflectedText": "くる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 130946,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "暮れ",
+                    "reading": "くれ",
+                    "sources": [
+                      {
+                        "originalText": "くれ",
+                        "transformedText": "くれ",
+                        "deinflectedText": "くれ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23590",
+                    "displayValueParsed": false,
+                    "frequency": 23590,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "206658㋕",
+                    "displayValueParsed": false,
+                    "frequency": 206658,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12877㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12877,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "20373",
+                    "displayValueParsed": false,
+                    "frequency": 20373,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 17054,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "暮",
+                    "reading": "くれ",
+                    "sources": [
+                      {
+                        "originalText": "くれ",
+                        "transformedText": "くれ",
+                        "deinflectedText": "くれ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "26155",
+                    "displayValueParsed": false,
+                    "frequency": 26155,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "206658㋕",
+                    "displayValueParsed": false,
+                    "frequency": 206658,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12877㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12877,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "33538",
+                    "displayValueParsed": false,
+                    "frequency": 33538,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 54086,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "クレ",
+                    "reading": "クレ",
+                    "sources": [
+                      {
+                        "originalText": "くれ",
+                        "transformedText": "クレ",
+                        "deinflectedText": "クレ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "61986㋕",
+                    "displayValueParsed": false,
+                    "frequency": 61986,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 1,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "く",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16536,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "区",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5333",
+                    "displayValueParsed": false,
+                    "frequency": 5333,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8408",
+                    "displayValueParsed": false,
+                    "frequency": 8408,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4365,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "句",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15976",
+                    "displayValueParsed": false,
+                    "frequency": 15976,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "26161",
+                    "displayValueParsed": false,
+                    "frequency": 26161,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 12180,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 197,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "九",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8115,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 96,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "９",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 95,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "玖",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "口",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "24209",
+                    "displayValueParsed": false,
+                    "frequency": 24209,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "257996㋕",
+                    "displayValueParsed": false,
+                    "frequency": 257996,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 118438,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "垢",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "126601",
+                    "displayValueParsed": false,
+                    "frequency": 126601,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "矩",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "208293",
+                    "displayValueParsed": false,
+                    "frequency": 208293,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 124056,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "苦",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7738",
+                    "displayValueParsed": false,
+                    "frequency": 7738,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "7172",
+                    "displayValueParsed": false,
+                    "frequency": 7172,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8025,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "躯",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "231447",
+                    "displayValueParsed": false,
+                    "frequency": 231447,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 68383,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "軀",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 139105,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "れてありがとう",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "れる",
+                    "reading": "れる",
+                    "sources": [
+                      {
+                        "originalText": "れて",
+                        "transformedText": "れて",
+                        "deinflectedText": "れる",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2225㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2225,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 20,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "レ",
+                    "reading": "レ",
+                    "sources": [
+                      {
+                        "originalText": "れ",
+                        "transformedText": "レ",
+                        "deinflectedText": "レ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "17373㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17373,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "209449㋕",
+                    "displayValueParsed": false,
+                    "frequency": 209449,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62775,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "てありがとう",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 199,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "て",
+                    "reading": "て",
+                    "sources": [
+                      {
+                        "originalText": "て",
+                        "transformedText": "て",
+                        "deinflectedText": "て",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      },
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "159㋕",
+                    "displayValueParsed": false,
+                    "frequency": 159,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "450㋕",
+                    "displayValueParsed": false,
+                    "frequency": 450,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "手",
+                    "reading": "て",
+                    "sources": [
+                      {
+                        "originalText": "て",
+                        "transformedText": "て",
+                        "deinflectedText": "て",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "114",
+                    "displayValueParsed": false,
+                    "frequency": 114,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "154",
+                    "displayValueParsed": false,
+                    "frequency": 154,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12492㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12492,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 200,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 122414,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "てる",
+                    "reading": "てる",
+                    "sources": [
+                      {
+                        "originalText": "て",
+                        "transformedText": "て",
+                        "deinflectedText": "てる",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1580㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1580,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "57901㋕",
+                    "displayValueParsed": false,
+                    "frequency": 57901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1094㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1094,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 54,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ありがとう",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 5,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ありがとう",
+                    "reading": "ありがとう",
+                    "sources": [
+                      {
+                        "originalText": "ありがとう",
+                        "transformedText": "ありがとう",
+                        "deinflectedText": "ありがとう",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "508㋕",
+                    "displayValueParsed": false,
+                    "frequency": 508,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "185㋕",
+                    "displayValueParsed": false,
+                    "frequency": 185,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 742,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 5,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有難う",
+                    "reading": "ありがとう",
+                    "sources": [
+                      {
+                        "originalText": "ありがとう",
+                        "transformedText": "ありがとう",
+                        "deinflectedText": "ありがとう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "508㋕",
+                    "displayValueParsed": false,
+                    "frequency": 508,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "28578",
+                    "displayValueParsed": false,
+                    "frequency": 28578,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "185㋕",
+                    "displayValueParsed": false,
+                    "frequency": 185,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "49799",
+                    "displayValueParsed": false,
+                    "frequency": 49799,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 7923,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 155143,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 98,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 5,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有り難う",
+                    "reading": "ありがとう",
+                    "sources": [
+                      {
+                        "originalText": "ありがとう",
+                        "transformedText": "ありがとう",
+                        "deinflectedText": "ありがとう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "508㋕",
+                    "displayValueParsed": false,
+                    "frequency": 508,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "60977",
+                    "displayValueParsed": false,
+                    "frequency": 60977,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "185㋕",
+                    "displayValueParsed": false,
+                    "frequency": 185,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "71118",
+                    "displayValueParsed": false,
+                    "frequency": 71118,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 328,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-く",
+                        "description": "Adverbial form of i-adjectives.\n"
+                      },
+                      {
+                        "name": "kansai-ben",
+                        "description": "-く stem of kansai-ben adjectives"
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 5,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有難い",
+                    "reading": "ありがたい",
+                    "sources": [
+                      {
+                        "originalText": "ありがとう",
+                        "transformedText": "ありがとう",
+                        "deinflectedText": "ありがたい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1753㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1753,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "13586",
+                    "displayValueParsed": false,
+                    "frequency": 13586,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1330㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1330,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25310",
+                    "displayValueParsed": false,
+                    "frequency": 25310,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 15686,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-く",
+                        "description": "Adverbial form of i-adjectives.\n"
+                      },
+                      {
+                        "name": "kansai-ben",
+                        "description": "-く stem of kansai-ben adjectives"
+                      }
+                    ]
+                  }
+                ],
+                "score": 199,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 5,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有り難い",
+                    "reading": "ありがたい",
+                    "sources": [
+                      {
+                        "originalText": "ありがとう",
+                        "transformedText": "ありがとう",
+                        "deinflectedText": "ありがたい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1753㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1753,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15209",
+                    "displayValueParsed": false,
+                    "frequency": 15209,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1330㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1330,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "20638",
+                    "displayValueParsed": false,
+                    "frequency": 20638,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2484,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ありがと",
+                    "reading": "ありがと",
+                    "sources": [
+                      {
+                        "originalText": "ありがと",
+                        "transformedText": "ありがと",
+                        "deinflectedText": "ありがと",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1871㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1871,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "915㋕",
+                    "displayValueParsed": false,
+                    "frequency": 915,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -104,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "あり",
+                    "reading": "あり",
+                    "sources": [
+                      {
+                        "originalText": "あり",
+                        "transformedText": "あり",
+                        "deinflectedText": "あり",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "275㋕",
+                    "displayValueParsed": false,
+                    "frequency": 275,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "122401㋕",
+                    "displayValueParsed": false,
+                    "frequency": 122401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "44806㋕",
+                    "displayValueParsed": false,
+                    "frequency": 44806,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4014,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "蟻",
+                    "reading": "あり",
+                    "sources": [
+                      {
+                        "originalText": "あり",
+                        "transformedText": "あり",
+                        "deinflectedText": "あり",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11975",
+                    "displayValueParsed": false,
+                    "frequency": 11975,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "122401㋕",
+                    "displayValueParsed": false,
+                    "frequency": 122401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1863㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1863,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "18530",
+                    "displayValueParsed": false,
+                    "frequency": 18530,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22750,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "在り",
+                    "reading": "あり",
+                    "sources": [
+                      {
+                        "originalText": "あり",
+                        "transformedText": "あり",
+                        "deinflectedText": "あり",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "275㋕",
+                    "displayValueParsed": false,
+                    "frequency": 275,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "124877",
+                    "displayValueParsed": false,
+                    "frequency": 124877,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3618㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3618,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "54035",
+                    "displayValueParsed": false,
+                    "frequency": 54035,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 115693,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有り",
+                    "reading": "あり",
+                    "sources": [
+                      {
+                        "originalText": "あり",
+                        "transformedText": "あり",
+                        "deinflectedText": "あり",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "275㋕",
+                    "displayValueParsed": false,
+                    "frequency": 275,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21147",
+                    "displayValueParsed": false,
+                    "frequency": 21147,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3618㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3618,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "20891",
+                    "displayValueParsed": false,
+                    "frequency": 20891,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2079,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有",
+                    "reading": "あり",
+                    "sources": [
+                      {
+                        "originalText": "あり",
+                        "transformedText": "あり",
+                        "deinflectedText": "あり",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3618㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3618,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "85328",
+                    "displayValueParsed": false,
+                    "frequency": 85328,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145835,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有る",
+                    "reading": "ある",
+                    "sources": [
+                      {
+                        "originalText": "あり",
+                        "transformedText": "あり",
+                        "deinflectedText": "ある",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8447",
+                    "displayValueParsed": false,
+                    "frequency": 8447,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5639",
+                    "displayValueParsed": false,
+                    "frequency": 5639,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 21,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 199,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "在る",
+                    "reading": "ある",
+                    "sources": [
+                      {
+                        "originalText": "あり",
+                        "transformedText": "あり",
+                        "deinflectedText": "ある",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4553",
+                    "displayValueParsed": false,
+                    "frequency": 4553,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11283",
+                    "displayValueParsed": false,
+                    "frequency": 11283,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11443,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "アリ",
+                    "reading": "アリ",
+                    "sources": [
+                      {
+                        "originalText": "あり",
+                        "transformedText": "アリ",
+                        "deinflectedText": "アリ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5983㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5983,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4344㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4344,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9680,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 97,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "あ",
+                    "reading": "あ",
+                    "sources": [
+                      {
+                        "originalText": "あ",
+                        "transformedText": "あ",
+                        "deinflectedText": "あ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "522㋕",
+                    "displayValueParsed": false,
+                    "frequency": 522,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "43㋕",
+                    "displayValueParsed": false,
+                    "frequency": 43,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4087,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 50,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 7,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ア",
+                    "reading": "あ",
+                    "sources": [
+                      {
+                        "originalText": "あ",
+                        "transformedText": "あ",
+                        "deinflectedText": "あ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "SubMiner Character Dictionary",
+                    "dictionaryAlias": "SubMiner Character Dictionary"
+                  },
+                  {
+                    "dictionary": "SubMiner Character Dictionary",
+                    "dictionaryAlias": "SubMiner Character Dictionary"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "94137㋕",
+                    "displayValueParsed": false,
+                    "frequency": 94137,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亜",
+                    "reading": "あ",
+                    "sources": [
+                      {
+                        "originalText": "あ",
+                        "transformedText": "あ",
+                        "deinflectedText": "あ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "13736",
+                    "displayValueParsed": false,
+                    "frequency": 13736,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "20831",
+                    "displayValueParsed": false,
+                    "frequency": 20831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 19536,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "阿",
+                    "reading": "あ",
+                    "sources": [
+                      {
+                        "originalText": "あ",
+                        "transformedText": "あ",
+                        "deinflectedText": "あ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23485",
+                    "displayValueParsed": false,
+                    "frequency": 23485,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "31874",
+                    "displayValueParsed": false,
+                    "frequency": 31874,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 121223,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "唖",
+                    "reading": "あ",
+                    "sources": [
+                      {
+                        "originalText": "あ",
+                        "transformedText": "あ",
+                        "deinflectedText": "あ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "66147㋕",
+                    "displayValueParsed": false,
+                    "frequency": 66147,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 148372,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150714,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -3,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "啞",
+                    "reading": "あ",
+                    "sources": [
+                      {
+                        "originalText": "あ",
+                        "transformedText": "あ",
+                        "deinflectedText": "あ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "66147㋕",
+                    "displayValueParsed": false,
+                    "frequency": 66147,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 157919,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -106,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "我",
+                    "reading": "あ",
+                    "sources": [
+                      {
+                        "originalText": "あ",
+                        "transformedText": "あ",
+                        "deinflectedText": "あ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "98243㋕",
+                    "displayValueParsed": false,
+                    "frequency": 98243,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 136539,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -107,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "吾",
+                    "reading": "あ",
+                    "sources": [
+                      {
+                        "originalText": "あ",
+                        "transformedText": "あ",
+                        "deinflectedText": "あ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "98243㋕",
+                    "displayValueParsed": false,
+                    "frequency": 98243,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 96,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ア",
+                    "reading": "ア",
+                    "sources": [
+                      {
+                        "originalText": "あ",
+                        "transformedText": "ア",
+                        "deinflectedText": "ア",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "94137㋕",
+                    "displayValueParsed": false,
+                    "frequency": 94137,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 51103,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 5
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "りがとう",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "リガ",
+                    "reading": "リガ",
+                    "sources": [
+                      {
+                        "originalText": "りが",
+                        "transformedText": "リガ",
+                        "deinflectedText": "リガ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "76496㋕",
+                    "displayValueParsed": false,
+                    "frequency": 76496,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "69696㋕",
+                    "displayValueParsed": false,
+                    "frequency": 69696,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46236,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "り",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30156㋕",
+                    "displayValueParsed": false,
+                    "frequency": 30156,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 626,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "利",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6473",
+                    "displayValueParsed": false,
+                    "frequency": 6473,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10411",
+                    "displayValueParsed": false,
+                    "frequency": 10411,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 15645,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 152148,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "理",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8718",
+                    "displayValueParsed": false,
+                    "frequency": 8718,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6203",
+                    "displayValueParsed": false,
+                    "frequency": 6203,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6444,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 80970,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "里",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9301",
+                    "displayValueParsed": false,
+                    "frequency": 9301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23938",
+                    "displayValueParsed": false,
+                    "frequency": 23938,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9622,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "吏",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "48918",
+                    "displayValueParsed": false,
+                    "frequency": 48918,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "64138",
+                    "displayValueParsed": false,
+                    "frequency": 64138,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "痢",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "148367",
+                    "displayValueParsed": false,
+                    "frequency": 148367,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "113606",
+                    "displayValueParsed": false,
+                    "frequency": 113606,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 120684,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "裏",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "52801",
+                    "displayValueParsed": false,
+                    "frequency": 52801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "64515",
+                    "displayValueParsed": false,
+                    "frequency": 64515,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 40664,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "離",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "20401",
+                    "displayValueParsed": false,
+                    "frequency": 20401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15639",
+                    "displayValueParsed": false,
+                    "frequency": 15639,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 42779,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 129769,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "裡",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18415",
+                    "displayValueParsed": false,
+                    "frequency": 18415,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "68690",
+                    "displayValueParsed": false,
+                    "frequency": 68690,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 57872,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "厘",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150890,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "釐",
+                    "reading": "り",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "り",
+                        "deinflectedText": "り",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "206619",
+                    "displayValueParsed": false,
+                    "frequency": 206619,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "リ",
+                    "reading": "リ",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "リ",
+                        "deinflectedText": "リ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6101㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6101,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10170,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "Ｒｅ：",
+                    "reading": "リ",
+                    "sources": [
+                      {
+                        "originalText": "り",
+                        "transformedText": "リ",
+                        "deinflectedText": "リ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "がとう",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "牙纛",
+                    "reading": "がとう",
+                    "sources": [
+                      {
+                        "originalText": "がとう",
+                        "transformedText": "がとう",
+                        "deinflectedText": "がとう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "瓦当",
+                    "reading": "がとう",
+                    "sources": [
+                      {
+                        "originalText": "がとう",
+                        "transformedText": "がとう",
+                        "deinflectedText": "がとう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134905,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -4,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "火灯",
+                    "reading": "がとう",
+                    "sources": [
+                      {
+                        "originalText": "がとう",
+                        "transformedText": "がとう",
+                        "deinflectedText": "がとう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -5,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "瓦灯",
+                    "reading": "がとう",
+                    "sources": [
+                      {
+                        "originalText": "がとう",
+                        "transformedText": "がとう",
+                        "deinflectedText": "がとう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -6,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "火頭",
+                    "reading": "がとう",
+                    "sources": [
+                      {
+                        "originalText": "がとう",
+                        "transformedText": "がとう",
+                        "deinflectedText": "がとう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "瓦當",
+                    "reading": "がとう",
+                    "sources": [
+                      {
+                        "originalText": "がとう",
+                        "transformedText": "がとう",
+                        "deinflectedText": "がとう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -107,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "瓦燈",
+                    "reading": "がとう",
+                    "sources": [
+                      {
+                        "originalText": "がとう",
+                        "transformedText": "がとう",
+                        "deinflectedText": "がとう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-く",
+                        "description": "Adverbial form of i-adjectives.\n"
+                      },
+                      {
+                        "name": "kansai-ben",
+                        "description": "-く stem of kansai-ben adjectives"
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "難い",
+                    "reading": "がたい",
+                    "sources": [
+                      {
+                        "originalText": "がとう",
+                        "transformedText": "がとう",
+                        "deinflectedText": "がたい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4009,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 114784,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "が",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 98,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "画",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17740㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17740,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6857,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 99577,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "我",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "43401",
+                    "displayValueParsed": false,
+                    "frequency": 43401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "22574",
+                    "displayValueParsed": false,
+                    "frequency": 22574,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 56290,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 136539,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "蛾",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "23270",
+                    "displayValueParsed": false,
+                    "frequency": 23270,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "29260",
+                    "displayValueParsed": false,
+                    "frequency": 29260,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22399,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "賀",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15246",
+                    "displayValueParsed": false,
+                    "frequency": 15246,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40227",
+                    "displayValueParsed": false,
+                    "frequency": 40227,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 47197,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "雅",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "43501",
+                    "displayValueParsed": false,
+                    "frequency": 43501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "153419",
+                    "displayValueParsed": false,
+                    "frequency": 153419,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "264167㋕",
+                    "displayValueParsed": false,
+                    "frequency": 264167,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 90509,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 144159,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "駕",
+                    "reading": "が",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "が",
+                        "deinflectedText": "が",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "33231",
+                    "displayValueParsed": false,
+                    "frequency": 33231,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "80386",
+                    "displayValueParsed": false,
+                    "frequency": 80386,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 95947,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ガ",
+                    "reading": "ガ",
+                    "sources": [
+                      {
+                        "originalText": "が",
+                        "transformedText": "ガ",
+                        "deinflectedText": "ガ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "16378㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16378,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18294㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18294,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "135016㋕",
+                    "displayValueParsed": false,
+                    "frequency": 135016,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14208㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14208,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 37336,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "とう",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "問う",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1164",
+                    "displayValueParsed": false,
+                    "frequency": 1164,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2664㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2664,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2498",
+                    "displayValueParsed": false,
+                    "frequency": 2498,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21256㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21256,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1555,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "党",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10801㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11245",
+                    "displayValueParsed": false,
+                    "frequency": 11245,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4074㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4074,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "18253",
+                    "displayValueParsed": false,
+                    "frequency": 18253,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5354,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "唐",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22915",
+                    "displayValueParsed": false,
+                    "frequency": 22915,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "151501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 151501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "33207",
+                    "displayValueParsed": false,
+                    "frequency": 33207,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16483,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "塔",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3677",
+                    "displayValueParsed": false,
+                    "frequency": 3677,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6764",
+                    "displayValueParsed": false,
+                    "frequency": 6764,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5839,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "糖",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "43439",
+                    "displayValueParsed": false,
+                    "frequency": 43439,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "255801㋕",
+                    "displayValueParsed": false,
+                    "frequency": 255801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "37302",
+                    "displayValueParsed": false,
+                    "frequency": 37302,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10460,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "頭",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5501",
+                    "displayValueParsed": false,
+                    "frequency": 5501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "92301㋕",
+                    "displayValueParsed": false,
+                    "frequency": 92301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10001",
+                    "displayValueParsed": false,
+                    "frequency": 10001,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "196720㋕",
+                    "displayValueParsed": false,
+                    "frequency": 196720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5117,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 142968,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "訪う",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2664㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2664,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "78001",
+                    "displayValueParsed": false,
+                    "frequency": 78001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21256㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21256,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "86840",
+                    "displayValueParsed": false,
+                    "frequency": 86840,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 153369,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "刀",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 29934,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150672,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "杜宇",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "疾う",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "149659",
+                    "displayValueParsed": false,
+                    "frequency": 149659,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "99633",
+                    "displayValueParsed": false,
+                    "frequency": 99633,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 107798,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "島",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5503",
+                    "displayValueParsed": false,
+                    "frequency": 5503,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8370",
+                    "displayValueParsed": false,
+                    "frequency": 8370,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4207,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 118882,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "当",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7369",
+                    "displayValueParsed": false,
+                    "frequency": 7369,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3890",
+                    "displayValueParsed": false,
+                    "frequency": 3890,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 524,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 138477,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "投",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18936",
+                    "displayValueParsed": false,
+                    "frequency": 18936,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19952",
+                    "displayValueParsed": false,
+                    "frequency": 19952,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 43040,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "東",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "87011",
+                    "displayValueParsed": false,
+                    "frequency": 87011,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 51466,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 130461,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "棟",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22802",
+                    "displayValueParsed": false,
+                    "frequency": 22802,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "85792",
+                    "displayValueParsed": false,
+                    "frequency": 85792,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143㋕",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 60234,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "灯",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "16001",
+                    "displayValueParsed": false,
+                    "frequency": 16001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "26601㋕",
+                    "displayValueParsed": false,
+                    "frequency": 26601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "28243",
+                    "displayValueParsed": false,
+                    "frequency": 28243,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995㋕",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 15000,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "等",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2659",
+                    "displayValueParsed": false,
+                    "frequency": 2659,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3770",
+                    "displayValueParsed": false,
+                    "frequency": 3770,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 146,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 154009,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "筒",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36316",
+                    "displayValueParsed": false,
+                    "frequency": 36316,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 42728,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "籐",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "40959",
+                    "displayValueParsed": false,
+                    "frequency": 40959,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "57641",
+                    "displayValueParsed": false,
+                    "frequency": 57641,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 49119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "薹",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "231447",
+                    "displayValueParsed": false,
+                    "frequency": 231447,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 107008,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "纛",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "燈",
+                    "reading": "とう",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "とう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22930",
+                    "displayValueParsed": false,
+                    "frequency": 22930,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "26601㋕",
+                    "displayValueParsed": false,
+                    "frequency": 26601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "43984",
+                    "displayValueParsed": false,
+                    "frequency": 43984,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995㋕",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 73687,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-く",
+                        "description": "Adverbial form of i-adjectives.\n"
+                      },
+                      {
+                        "name": "kansai-ben",
+                        "description": "-く stem of kansai-ben adjectives"
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "たい",
+                    "reading": "たい",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "とう",
+                        "deinflectedText": "たい",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75905㋕",
+                    "displayValueParsed": false,
+                    "frequency": 75905,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "99199㋕",
+                    "displayValueParsed": false,
+                    "frequency": 99199,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "255239㋕",
+                    "displayValueParsed": false,
+                    "frequency": 255239,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "274038㋕",
+                    "displayValueParsed": false,
+                    "frequency": 274038,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19204㋕",
+                    "displayValueParsed": false,
+                    "frequency": 19204,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 40,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "トウ",
+                    "reading": "トウ",
+                    "sources": [
+                      {
+                        "originalText": "とう",
+                        "transformedText": "トウ",
+                        "deinflectedText": "トウ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "38671㋕",
+                    "displayValueParsed": false,
+                    "frequency": 38671,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "177001㋕",
+                    "displayValueParsed": false,
+                    "frequency": 177001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "286883㋕",
+                    "displayValueParsed": false,
+                    "frequency": 286883,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26066,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "と",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "戸",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3806",
+                    "displayValueParsed": false,
+                    "frequency": 3806,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5558",
+                    "displayValueParsed": false,
+                    "frequency": 5558,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18575,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 116932,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "斗",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "20270",
+                    "displayValueParsed": false,
+                    "frequency": 20270,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23670",
+                    "displayValueParsed": false,
+                    "frequency": 23670,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 33001,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "途",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24217",
+                    "displayValueParsed": false,
+                    "frequency": 24217,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "31921",
+                    "displayValueParsed": false,
+                    "frequency": 31921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 54709,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 146147,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "門",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "93601",
+                    "displayValueParsed": false,
+                    "frequency": 93601,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "十",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "人",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22801",
+                    "displayValueParsed": false,
+                    "frequency": 22801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 74510,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "堵",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75328",
+                    "displayValueParsed": false,
+                    "frequency": 75328,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "106346",
+                    "displayValueParsed": false,
+                    "frequency": 106346,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 111823,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "う",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "う",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "206㋕",
+                    "displayValueParsed": false,
+                    "frequency": 206,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9411,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "卯",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "40163",
+                    "displayValueParsed": false,
+                    "frequency": 40163,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "61505",
+                    "displayValueParsed": false,
+                    "frequency": 61505,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 55581,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 147477,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "宇",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "41402",
+                    "displayValueParsed": false,
+                    "frequency": 41402,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46946,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 159206,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "得",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "46669㋕",
+                    "displayValueParsed": false,
+                    "frequency": 46669,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "111527",
+                    "displayValueParsed": false,
+                    "frequency": 111527,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "33602",
+                    "displayValueParsed": false,
+                    "frequency": 33602,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "61060",
+                    "displayValueParsed": false,
+                    "frequency": 61060,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18901,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145835,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "竽",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "247924",
+                    "displayValueParsed": false,
+                    "frequency": 247924,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "279165",
+                    "displayValueParsed": false,
+                    "frequency": 279165,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "羽",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "62501",
+                    "displayValueParsed": false,
+                    "frequency": 62501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "117275",
+                    "displayValueParsed": false,
+                    "frequency": 117275,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 115134,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 122375,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鵜",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "31146",
+                    "displayValueParsed": false,
+                    "frequency": 31146,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "66994",
+                    "displayValueParsed": false,
+                    "frequency": 66994,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 35994,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "諾",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鰻",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -104,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "兎",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "優",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 159848,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ウ",
+                    "reading": "ウ",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "ウ",
+                        "deinflectedText": "ウ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18682㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18682,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "71893㋕",
+                    "displayValueParsed": false,
+                    "frequency": 71893,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3466㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3466,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 15980,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "手伝う",
+              "reading": "てつだって"
+            },
+            {
+              "term": "手伝って",
+              "reading": "てつだって"
+            },
+            {
+              "term": "呉れ手",
+              "reading": "くれて"
+            },
+            {
+              "term": "くれて",
+              "reading": "くれて"
+            },
+            {
+              "term": "ありがとう",
+              "reading": "ありがとう"
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "呉れ手",
+              "reading": "くれて",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 128337,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "くれて",
+              "reading": "くれて",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 262287,
+              "displayValue": "262287㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "くれて",
+              "reading": "くれて",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 77097,
+              "displayValue": "77097㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "ありがとう",
+              "reading": "ありがとう",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 508,
+              "displayValue": "508㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "ありがとう",
+              "reading": "ありがとう",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 742,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "ありがとう",
+              "reading": "ありがとう",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 185,
+              "displayValue": "185㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "手伝う",
+              "reading": null
+            },
+            {
+              "term": "手伝って",
+              "reading": null
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "手伝う",
+              "reading": "てつだう",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 854,
+              "displayValue": "854",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "手伝う",
+              "reading": "てつだう",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 59676,
+              "displayValue": "59676㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "手伝う",
+              "reading": "てつだう",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 3985,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "手伝う",
+              "reading": "てつだう",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 563,
+              "displayValue": "563",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "手伝う",
+              "reading": "てつだう",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 48110,
+              "displayValue": "48110㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      }
+    ],
+    "scripts": [
+      {
+        "sha256": "fb64f047eb0494f136bb92311df43c5318873298fe3efad6bfa82e5d531a93e1",
+        "marker": "optionsGetFull",
+        "result": {
+          "profileIndex": 0,
+          "scanLength": 21,
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ],
+          "dictionaryPriorityByName": {
+            "Jitendex.org [2026-03-05]": 0,
+            "日本語文法辞典(全集)": 1,
+            "JPDBv2㋕": 2,
+            "Jiten": 3,
+            "CC100": 4,
+            "実用日本語表現辞典": 5,
+            "NHK": 6,
+            "SubMiner Character Dictionary": 7
+          },
+          "dictionaryFrequencyModeByName": {
+            "JPDBv2㋕": "rank-based",
+            "Jiten": "rank-based"
+          }
+        }
+      },
+      {
+        "sha256": "7bb7876a0289caea90d2c9532743b68c1f2ebfabfef9c6ca98697162b23acb97",
+        "marker": "parseText",
+        "result": [
+          {
+            "id": "scan",
+            "source": "scanning-parser",
+            "dictionary": null,
+            "index": 0,
+            "content": [
+              [
+                {
+                  "text": "手伝",
+                  "reading": "てつだ",
+                  "headwords": [
+                    [
+                      {
+                        "term": "手伝う",
+                        "reading": "てつだう",
+                        "sources": [
+                          {
+                            "originalText": "手伝って",
+                            "transformedText": "手伝って",
+                            "deinflectedText": "手伝う",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "text": "って",
+                  "reading": ""
+                }
+              ],
+              [
+                {
+                  "text": "くれて",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "呉れ手",
+                        "reading": "くれて",
+                        "sources": [
+                          {
+                            "originalText": "くれて",
+                            "transformedText": "くれて",
+                            "deinflectedText": "くれて",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "くれる",
+                        "reading": "くれる",
+                        "sources": [
+                          {
+                            "originalText": "くれて",
+                            "transformedText": "くれて",
+                            "deinflectedText": "くれる",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "暮れる",
+                        "reading": "くれる",
+                        "sources": [
+                          {
+                            "originalText": "くれて",
+                            "transformedText": "くれて",
+                            "deinflectedText": "くれる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "呉れる",
+                        "reading": "くれる",
+                        "sources": [
+                          {
+                            "originalText": "くれて",
+                            "transformedText": "くれて",
+                            "deinflectedText": "くれる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "昏れる",
+                        "reading": "くれる",
+                        "sources": [
+                          {
+                            "originalText": "くれて",
+                            "transformedText": "くれて",
+                            "deinflectedText": "くれる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "眩れる",
+                        "reading": "くれる",
+                        "sources": [
+                          {
+                            "originalText": "くれて",
+                            "transformedText": "くれて",
+                            "deinflectedText": "くれる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "暗れる",
+                        "reading": "くれる",
+                        "sources": [
+                          {
+                            "originalText": "くれて",
+                            "transformedText": "くれて",
+                            "deinflectedText": "くれる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "昏れる",
+                        "reading": "くれる",
+                        "sources": [
+                          {
+                            "originalText": "くれて",
+                            "transformedText": "くれて",
+                            "deinflectedText": "くれる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "暮れる",
+                        "reading": "くれる",
+                        "sources": [
+                          {
+                            "originalText": "くれて",
+                            "transformedText": "くれて",
+                            "deinflectedText": "くれる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "繰る",
+                        "reading": "くる",
+                        "sources": [
+                          {
+                            "originalText": "くれて",
+                            "transformedText": "くれて",
+                            "deinflectedText": "くる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "刳る",
+                        "reading": "くる",
+                        "sources": [
+                          {
+                            "originalText": "くれて",
+                            "transformedText": "くれて",
+                            "deinflectedText": "くる",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "ありがとう",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "ありがとう",
+                        "reading": "ありがとう",
+                        "sources": [
+                          {
+                            "originalText": "ありがとう",
+                            "transformedText": "ありがとう",
+                            "deinflectedText": "ありがとう",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "有難う",
+                        "reading": "ありがとう",
+                        "sources": [
+                          {
+                            "originalText": "ありがとう",
+                            "transformedText": "ありがとう",
+                            "deinflectedText": "ありがとう",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "有り難う",
+                        "reading": "ありがとう",
+                        "sources": [
+                          {
+                            "originalText": "ありがとう",
+                            "transformedText": "ありがとう",
+                            "deinflectedText": "ありがとう",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "有難い",
+                        "reading": "ありがたい",
+                        "sources": [
+                          {
+                            "originalText": "ありがとう",
+                            "transformedText": "ありがとう",
+                            "deinflectedText": "ありがたい",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "有り難い",
+                        "reading": "ありがたい",
+                        "sources": [
+                          {
+                            "originalText": "ありがとう",
+                            "transformedText": "ありがとう",
+                            "deinflectedText": "ありがたい",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "d9a9a6523130348b6402552b5b24c5f20e985c637933c0978c5bacfb1760d28f",
+        "marker": "termsFind",
+        "result": [
+          {
+            "surface": "手伝って",
+            "reading": "てつだって",
+            "headword": "手伝う",
+            "headwordReading": "てつだう",
+            "startPos": 0,
+            "endPos": 4,
+            "isNameMatch": false,
+            "frequencyRank": 854,
+            "wordClasses": [
+              "v5"
+            ]
+          },
+          {
+            "surface": "くれて",
+            "reading": "くれて",
+            "headword": "呉れ手",
+            "headwordReading": "くれて",
+            "startPos": 4,
+            "endPos": 7,
+            "isNameMatch": false,
+            "frequencyRank": 128337
+          },
+          {
+            "surface": "ありがとう",
+            "reading": "ありがとう",
+            "headword": "ありがとう",
+            "headwordReading": "ありがとう",
+            "startPos": 7,
+            "endPos": 12,
+            "isNameMatch": false,
+            "frequencyRank": 508
+          }
+        ]
+      },
+      {
+        "sha256": "c115d39b2ccda24a6c54d6d8c361b4efaa1271f58e4fd1b771fd1693412e8f87",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "呉れ手",
+            "reading": "くれて",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 128337,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "くれて",
+            "reading": "くれて",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 262287,
+            "displayValue": "262287㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "くれて",
+            "reading": "くれて",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 77097,
+            "displayValue": "77097㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "ありがとう",
+            "reading": "ありがとう",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 508,
+            "displayValue": "508㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "ありがとう",
+            "reading": "ありがとう",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 742,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "ありがとう",
+            "reading": "ありがとう",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 185,
+            "displayValue": "185㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      },
+      {
+        "sha256": "7c052365da15217ea5144dc0098c09b47d2f6b5658719cf199e1b2fba2790441",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "手伝う",
+            "reading": "てつだう",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 854,
+            "displayValue": "854",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "手伝う",
+            "reading": "てつだう",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 59676,
+            "displayValue": "59676㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "手伝う",
+            "reading": "てつだう",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 3985,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "手伝う",
+            "reading": "てつだう",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 563,
+            "displayValue": "563",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "手伝う",
+            "reading": "てつだう",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 48110,
+            "displayValue": "48110㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      }
+    ],
+    "mecab": {
+      "手伝ってくれてありがとう": [
+        {
+          "word": "手伝っ",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "五段・ワ行促音便",
+          "inflectionForm": "連用タ接続",
+          "headword": "手伝う",
+          "katakanaReading": "テツダッ",
+          "pronunciation": "テツダッ"
+        },
+        {
+          "word": "て",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "接続助詞",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "て",
+          "katakanaReading": "テ",
+          "pronunciation": "テ"
+        },
+        {
+          "word": "くれ",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "非自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "一段・クレル",
+          "inflectionForm": "連用形",
+          "headword": "くれる",
+          "katakanaReading": "クレ",
+          "pronunciation": "クレ"
+        },
+        {
+          "word": "て",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "接続助詞",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "て",
+          "katakanaReading": "テ",
+          "pronunciation": "テ"
+        },
+        {
+          "word": "ありがとう",
+          "partOfSpeech": "other",
+          "pos1": "感動詞",
+          "pos2": "*",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "ありがとう",
+          "katakanaReading": "アリガトウ",
+          "pronunciation": "アリガトー"
+        }
+      ]
+    }
+  },
+  "expected": {
+    "tokens": [
+      {
+        "surface": "手伝って",
+        "reading": "てつだって",
+        "headword": "手伝う",
+        "startPos": 0,
+        "endPos": 4,
+        "partOfSpeech": "verb",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "てつだう",
+        "pos1": "動詞",
+        "pos2": "自立",
+        "pos3": "*",
+        "frequencyRank": 854
+      },
+      {
+        "surface": "くれて",
+        "reading": "くれて",
+        "headword": "呉れ手",
+        "startPos": 4,
+        "endPos": 7,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "くれて",
+        "pos1": "動詞",
+        "pos2": "自立",
+        "pos3": "*",
+        "frequencyRank": 128337
+      },
+      {
+        "surface": "ありがとう",
+        "reading": "ありがとう",
+        "headword": "ありがとう",
+        "startPos": 7,
+        "endPos": 12,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "ありがとう",
+        "pos1": "感動詞",
+        "pos2": "*",
+        "pos3": "*"
+      }
+    ]
+  }
+}

--- a/src/core/services/tokenizer/__fixtures__/golden/monka-rhetorical.json
+++ b/src/core/services/tokenizer/__fixtures__/golden/monka-rhetorical.json
@@ -1,0 +1,6801 @@
+{
+  "name": "monka-rhetorical",
+  "description": "rhetorical monka phrase stays plain",
+  "recordedAt": "2026-07-11T00:50:00.178Z",
+  "input": {
+    "text": "行くもんか"
+  },
+  "config": {},
+  "recording": {
+    "messages": [
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "parseText",
+        "params": {
+          "text": "行くもんか",
+          "optionsContext": {
+            "index": 0
+          },
+          "scanLength": 21,
+          "useInternalParser": true,
+          "useMecabParser": false
+        },
+        "response": {
+          "result": [
+            {
+              "id": "scan",
+              "source": "scanning-parser",
+              "dictionary": null,
+              "index": 0,
+              "content": [
+                [
+                  {
+                    "text": "行",
+                    "reading": "い",
+                    "headwords": [
+                      [
+                        {
+                          "term": "行く",
+                          "reading": "いく",
+                          "sources": [
+                            {
+                              "originalText": "行く",
+                              "transformedText": "行く",
+                              "deinflectedText": "行く",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "行く",
+                          "reading": "ゆく",
+                          "sources": [
+                            {
+                              "originalText": "行く",
+                              "transformedText": "行く",
+                              "deinflectedText": "行く",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "text": "く",
+                    "reading": ""
+                  }
+                ],
+                [
+                  {
+                    "text": "もんか",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "もんか",
+                          "reading": "もんか",
+                          "sources": [
+                            {
+                              "originalText": "もんか",
+                              "transformedText": "もんか",
+                              "deinflectedText": "もんか",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "門下",
+                          "reading": "もんか",
+                          "sources": [
+                            {
+                              "originalText": "もんか",
+                              "transformedText": "もんか",
+                              "deinflectedText": "もんか",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "紋菓",
+                          "reading": "もんか",
+                          "sources": [
+                            {
+                              "originalText": "もんか",
+                              "transformedText": "もんか",
+                              "deinflectedText": "もんか",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "行くもんか",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "行く",
+                    "reading": "いく",
+                    "sources": [
+                      {
+                        "originalText": "行く",
+                        "transformedText": "行く",
+                        "deinflectedText": "行く",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "44",
+                    "displayValueParsed": false,
+                    "frequency": 44,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "65㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "64",
+                    "displayValueParsed": false,
+                    "frequency": 64,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "199㋕",
+                    "displayValueParsed": false,
+                    "frequency": 199,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 38,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 50649,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 198,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "行く",
+                    "reading": "ゆく",
+                    "sources": [
+                      {
+                        "originalText": "行く",
+                        "transformedText": "行く",
+                        "deinflectedText": "行く",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2161㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2161,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 50649,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "行",
+                    "reading": "ぎょう",
+                    "sources": [
+                      {
+                        "originalText": "行",
+                        "transformedText": "行",
+                        "deinflectedText": "行",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7801",
+                    "displayValueParsed": false,
+                    "frequency": 7801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "33017㋕",
+                    "displayValueParsed": false,
+                    "frequency": 33017,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3120",
+                    "displayValueParsed": false,
+                    "frequency": 3120,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "49335㋕",
+                    "displayValueParsed": false,
+                    "frequency": 49335,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3192,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 131144,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "行",
+                    "reading": "こう",
+                    "sources": [
+                      {
+                        "originalText": "行",
+                        "transformedText": "行",
+                        "deinflectedText": "行",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5760",
+                    "displayValueParsed": false,
+                    "frequency": 5760,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "177201㋕",
+                    "displayValueParsed": false,
+                    "frequency": 177201,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21948",
+                    "displayValueParsed": false,
+                    "frequency": 21948,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 56366,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 131144,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "行",
+                    "reading": "くだり",
+                    "sources": [
+                      {
+                        "originalText": "行",
+                        "transformedText": "行",
+                        "deinflectedText": "行",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 131144,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "くもんか",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "公文",
+                    "reading": "くもん",
+                    "sources": [
+                      {
+                        "originalText": "くもん",
+                        "transformedText": "くもん",
+                        "deinflectedText": "くもん",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "190195",
+                    "displayValueParsed": false,
+                    "frequency": 190195,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 113306,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 129703,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "苦悶",
+                    "reading": "くもん",
+                    "sources": [
+                      {
+                        "originalText": "くもん",
+                        "transformedText": "くもん",
+                        "deinflectedText": "くもん",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8876",
+                    "displayValueParsed": false,
+                    "frequency": 8876,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "58296㋕",
+                    "displayValueParsed": false,
+                    "frequency": 58296,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11444",
+                    "displayValueParsed": false,
+                    "frequency": 11444,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "64993㋕",
+                    "displayValueParsed": false,
+                    "frequency": 64993,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 32068,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "蜘蛛",
+                    "reading": "くも",
+                    "sources": [
+                      {
+                        "originalText": "くも",
+                        "transformedText": "くも",
+                        "deinflectedText": "くも",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9061",
+                    "displayValueParsed": false,
+                    "frequency": 9061,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14991㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14991,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17745",
+                    "displayValueParsed": false,
+                    "frequency": 17745,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 12997,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "雲",
+                    "reading": "くも",
+                    "sources": [
+                      {
+                        "originalText": "くも",
+                        "transformedText": "くも",
+                        "deinflectedText": "くも",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2105",
+                    "displayValueParsed": false,
+                    "frequency": 2105,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3106",
+                    "displayValueParsed": false,
+                    "frequency": 3106,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21603㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21603,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3891,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 96,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "クモ",
+                    "reading": "クモ",
+                    "sources": [
+                      {
+                        "originalText": "くも",
+                        "transformedText": "クモ",
+                        "deinflectedText": "クモ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21197㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21197,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17251㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17251,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 1,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "く",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16536,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "区",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5333",
+                    "displayValueParsed": false,
+                    "frequency": 5333,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8408",
+                    "displayValueParsed": false,
+                    "frequency": 8408,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4365,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "句",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15976",
+                    "displayValueParsed": false,
+                    "frequency": 15976,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "26161",
+                    "displayValueParsed": false,
+                    "frequency": 26161,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 12180,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 197,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "九",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8115,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 96,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "９",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 95,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "玖",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "口",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "24209",
+                    "displayValueParsed": false,
+                    "frequency": 24209,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "257996㋕",
+                    "displayValueParsed": false,
+                    "frequency": 257996,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 118438,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "垢",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "126601",
+                    "displayValueParsed": false,
+                    "frequency": 126601,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "矩",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "208293",
+                    "displayValueParsed": false,
+                    "frequency": 208293,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 124056,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "苦",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7738",
+                    "displayValueParsed": false,
+                    "frequency": 7738,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "7172",
+                    "displayValueParsed": false,
+                    "frequency": 7172,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8025,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "躯",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "231447",
+                    "displayValueParsed": false,
+                    "frequency": 231447,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 68383,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "軀",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 139105,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "もんか",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "もんか",
+                    "reading": "もんか",
+                    "sources": [
+                      {
+                        "originalText": "もんか",
+                        "transformedText": "もんか",
+                        "deinflectedText": "もんか",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "132013㋕",
+                    "displayValueParsed": false,
+                    "frequency": 132013,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "205847㋕",
+                    "displayValueParsed": false,
+                    "frequency": 205847,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "69629㋕",
+                    "displayValueParsed": false,
+                    "frequency": 69629,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "門下",
+                    "reading": "もんか",
+                    "sources": [
+                      {
+                        "originalText": "もんか",
+                        "transformedText": "もんか",
+                        "deinflectedText": "もんか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "38455",
+                    "displayValueParsed": false,
+                    "frequency": 38455,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "205847㋕",
+                    "displayValueParsed": false,
+                    "frequency": 205847,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12213㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12213,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "53300",
+                    "displayValueParsed": false,
+                    "frequency": 53300,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 39779,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "紋菓",
+                    "reading": "もんか",
+                    "sources": [
+                      {
+                        "originalText": "もんか",
+                        "transformedText": "もんか",
+                        "deinflectedText": "もんか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "もん",
+                    "reading": "もん",
+                    "sources": [
+                      {
+                        "originalText": "もん",
+                        "transformedText": "もん",
+                        "deinflectedText": "もん",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "538㋕",
+                    "displayValueParsed": false,
+                    "frequency": 538,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "601㋕",
+                    "displayValueParsed": false,
+                    "frequency": 601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "68701㋕",
+                    "displayValueParsed": false,
+                    "frequency": 68701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "190801㋕",
+                    "displayValueParsed": false,
+                    "frequency": 190801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "262201㋕",
+                    "displayValueParsed": false,
+                    "frequency": 262201,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "180㋕",
+                    "displayValueParsed": false,
+                    "frequency": 180,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3711,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "問",
+                    "reading": "もん",
+                    "sources": [
+                      {
+                        "originalText": "もん",
+                        "transformedText": "もん",
+                        "deinflectedText": "もん",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18301",
+                    "displayValueParsed": false,
+                    "frequency": 18301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13899",
+                    "displayValueParsed": false,
+                    "frequency": 13899,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8984,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "紋",
+                    "reading": "もん",
+                    "sources": [
+                      {
+                        "originalText": "もん",
+                        "transformedText": "もん",
+                        "deinflectedText": "もん",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10747",
+                    "displayValueParsed": false,
+                    "frequency": 10747,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "68701㋕",
+                    "displayValueParsed": false,
+                    "frequency": 68701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "22062",
+                    "displayValueParsed": false,
+                    "frequency": 22062,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 19151,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "門",
+                    "reading": "もん",
+                    "sources": [
+                      {
+                        "originalText": "もん",
+                        "transformedText": "もん",
+                        "deinflectedText": "もん",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1653",
+                    "displayValueParsed": false,
+                    "frequency": 1653,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "190801㋕",
+                    "displayValueParsed": false,
+                    "frequency": 190801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2965",
+                    "displayValueParsed": false,
+                    "frequency": 2965,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5284,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "文",
+                    "reading": "もん",
+                    "sources": [
+                      {
+                        "originalText": "もん",
+                        "transformedText": "もん",
+                        "deinflectedText": "もん",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "59701",
+                    "displayValueParsed": false,
+                    "frequency": 59701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 83143,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134746,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "物",
+                    "reading": "もん",
+                    "sources": [
+                      {
+                        "originalText": "もん",
+                        "transformedText": "もん",
+                        "deinflectedText": "もん",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "180㋕",
+                    "displayValueParsed": false,
+                    "frequency": 180,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 118407,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "者",
+                    "reading": "もん",
+                    "sources": [
+                      {
+                        "originalText": "もん",
+                        "transformedText": "もん",
+                        "deinflectedText": "もん",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134223,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "悶",
+                    "reading": "もん",
+                    "sources": [
+                      {
+                        "originalText": "もん",
+                        "transformedText": "もん",
+                        "deinflectedText": "もん",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "43237",
+                    "displayValueParsed": false,
+                    "frequency": 43237,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "66602",
+                    "displayValueParsed": false,
+                    "frequency": 66602,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "も",
+                    "reading": "も",
+                    "sources": [
+                      {
+                        "originalText": "も",
+                        "transformedText": "も",
+                        "deinflectedText": "も",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "7㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 13,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "喪",
+                    "reading": "も",
+                    "sources": [
+                      {
+                        "originalText": "も",
+                        "transformedText": "も",
+                        "deinflectedText": "も",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29971",
+                    "displayValueParsed": false,
+                    "frequency": 29971,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "38373",
+                    "displayValueParsed": false,
+                    "frequency": 38373,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 25312,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "藻",
+                    "reading": "も",
+                    "sources": [
+                      {
+                        "originalText": "も",
+                        "transformedText": "も",
+                        "deinflectedText": "も",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "26345",
+                    "displayValueParsed": false,
+                    "frequency": 26345,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36194",
+                    "displayValueParsed": false,
+                    "frequency": 36194,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "82455㋕",
+                    "displayValueParsed": false,
+                    "frequency": 82455,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26908,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "裳",
+                    "reading": "も",
+                    "sources": [
+                      {
+                        "originalText": "も",
+                        "transformedText": "も",
+                        "deinflectedText": "も",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "46035",
+                    "displayValueParsed": false,
+                    "frequency": 46035,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "79220",
+                    "displayValueParsed": false,
+                    "frequency": 79220,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 119221,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 130826,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "面",
+                    "reading": "も",
+                    "sources": [
+                      {
+                        "originalText": "も",
+                        "transformedText": "も",
+                        "deinflectedText": "も",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "んか",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ん",
+                    "reading": "ん",
+                    "sources": [
+                      {
+                        "originalText": "ん",
+                        "transformedText": "ん",
+                        "deinflectedText": "ん",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34001㋕",
+                    "displayValueParsed": false,
+                    "frequency": 34001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ン",
+                    "reading": "ン",
+                    "sources": [
+                      {
+                        "originalText": "ん",
+                        "transformedText": "ン",
+                        "deinflectedText": "ン",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8493㋕",
+                    "displayValueParsed": false,
+                    "frequency": 8493,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1528㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1528,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27611,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "か",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "か",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 19,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "加",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "16448",
+                    "displayValueParsed": false,
+                    "frequency": 16448,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25781",
+                    "displayValueParsed": false,
+                    "frequency": 25781,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26419,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "可",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9467",
+                    "displayValueParsed": false,
+                    "frequency": 9467,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12633",
+                    "displayValueParsed": false,
+                    "frequency": 12633,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "57887㋕",
+                    "displayValueParsed": false,
+                    "frequency": 57887,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4319,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "科",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6581",
+                    "displayValueParsed": false,
+                    "frequency": 6581,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8555",
+                    "displayValueParsed": false,
+                    "frequency": 8555,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3512,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 152614,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "蚊",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12258",
+                    "displayValueParsed": false,
+                    "frequency": 12258,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12952",
+                    "displayValueParsed": false,
+                    "frequency": 12952,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8283,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "課",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8436",
+                    "displayValueParsed": false,
+                    "frequency": 8436,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6393",
+                    "displayValueParsed": false,
+                    "frequency": 6393,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "69624㋕",
+                    "displayValueParsed": false,
+                    "frequency": 69624,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5002,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "下",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2801",
+                    "displayValueParsed": false,
+                    "frequency": 2801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3986",
+                    "displayValueParsed": false,
+                    "frequency": 3986,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2971,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 105800,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "佳",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "36202",
+                    "displayValueParsed": false,
+                    "frequency": 36202,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47931",
+                    "displayValueParsed": false,
+                    "frequency": 47931,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "価",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "73601",
+                    "displayValueParsed": false,
+                    "frequency": 73601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47025",
+                    "displayValueParsed": false,
+                    "frequency": 47025,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 21934,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 153400,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "化",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2672",
+                    "displayValueParsed": false,
+                    "frequency": 2672,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2336",
+                    "displayValueParsed": false,
+                    "frequency": 2336,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 761,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夏",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "58901",
+                    "displayValueParsed": false,
+                    "frequency": 58901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "164018",
+                    "displayValueParsed": false,
+                    "frequency": 164018,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 28065,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "家",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3313",
+                    "displayValueParsed": false,
+                    "frequency": 3313,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3876,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 95167,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "寡",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "149762",
+                    "displayValueParsed": false,
+                    "frequency": 149762,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "戈",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "99657",
+                    "displayValueParsed": false,
+                    "frequency": 99657,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "115591",
+                    "displayValueParsed": false,
+                    "frequency": 115591,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 119581,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 141501,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "日",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21101",
+                    "displayValueParsed": false,
+                    "frequency": 21101,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "7733",
+                    "displayValueParsed": false,
+                    "frequency": 7733,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 56,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 76112,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "果",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "19261",
+                    "displayValueParsed": false,
+                    "frequency": 19261,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25313",
+                    "displayValueParsed": false,
+                    "frequency": 25313,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 114501,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "架",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29508",
+                    "displayValueParsed": false,
+                    "frequency": 29508,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "41525",
+                    "displayValueParsed": false,
+                    "frequency": 41525,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46930,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "火",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10501",
+                    "displayValueParsed": false,
+                    "frequency": 10501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13005",
+                    "displayValueParsed": false,
+                    "frequency": 13005,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24360,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 146483,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "禍",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "28455",
+                    "displayValueParsed": false,
+                    "frequency": 28455,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 97819,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 109488,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "箇",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "109501",
+                    "displayValueParsed": false,
+                    "frequency": 109501,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "荷",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "135702",
+                    "displayValueParsed": false,
+                    "frequency": 135702,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "347844",
+                    "displayValueParsed": false,
+                    "frequency": 347844,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "菓",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "68334",
+                    "displayValueParsed": false,
+                    "frequency": 68334,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "58453",
+                    "displayValueParsed": false,
+                    "frequency": 58453,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "華",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "20802",
+                    "displayValueParsed": false,
+                    "frequency": 20802,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25748",
+                    "displayValueParsed": false,
+                    "frequency": 25748,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 49439,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132548,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "過",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "16909",
+                    "displayValueParsed": false,
+                    "frequency": 16909,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "20624",
+                    "displayValueParsed": false,
+                    "frequency": 20624,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11225,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158292,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "顆",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "101577",
+                    "displayValueParsed": false,
+                    "frequency": 101577,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "113320",
+                    "displayValueParsed": false,
+                    "frequency": 113320,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "香",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10404",
+                    "displayValueParsed": false,
+                    "frequency": 10404,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "96731",
+                    "displayValueParsed": false,
+                    "frequency": 96731,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 20513,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 114119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "個",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "283101",
+                    "displayValueParsed": false,
+                    "frequency": 283101,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "个",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "96833",
+                    "displayValueParsed": false,
+                    "frequency": 96833,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "60507",
+                    "displayValueParsed": false,
+                    "frequency": 60507,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鹿",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "カ",
+                    "reading": "カ",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "カ",
+                        "deinflectedText": "カ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21344㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21344,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "25402㋕",
+                    "displayValueParsed": false,
+                    "frequency": 25402,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "57001㋕",
+                    "displayValueParsed": false,
+                    "frequency": 57001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "97601㋕",
+                    "displayValueParsed": false,
+                    "frequency": 97601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "190502㋕",
+                    "displayValueParsed": false,
+                    "frequency": 190502,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4690㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4690,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "行く",
+              "reading": "いく"
+            },
+            {
+              "term": "もんか",
+              "reading": "もんか"
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "行く",
+              "reading": "いく",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 44,
+              "displayValue": "44",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "行く",
+              "reading": "いく",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 65,
+              "displayValue": "65㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "行く",
+              "reading": "いく",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 38,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "行く",
+              "reading": "いく",
+              "dictionary": "CC100",
+              "hasReading": false,
+              "frequency": 50649,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "行く",
+              "reading": "いく",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 64,
+              "displayValue": "64",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "行く",
+              "reading": "いく",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 199,
+              "displayValue": "199㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "もんか",
+              "reading": "もんか",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 132013,
+              "displayValue": "132013㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "もんか",
+              "reading": "もんか",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 205847,
+              "displayValue": "205847㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "もんか",
+              "reading": "もんか",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 69629,
+              "displayValue": "69629㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      }
+    ],
+    "scripts": [
+      {
+        "sha256": "fb64f047eb0494f136bb92311df43c5318873298fe3efad6bfa82e5d531a93e1",
+        "marker": "optionsGetFull",
+        "result": {
+          "profileIndex": 0,
+          "scanLength": 21,
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ],
+          "dictionaryPriorityByName": {
+            "Jitendex.org [2026-03-05]": 0,
+            "日本語文法辞典(全集)": 1,
+            "JPDBv2㋕": 2,
+            "Jiten": 3,
+            "CC100": 4,
+            "実用日本語表現辞典": 5,
+            "NHK": 6,
+            "SubMiner Character Dictionary": 7
+          },
+          "dictionaryFrequencyModeByName": {
+            "JPDBv2㋕": "rank-based",
+            "Jiten": "rank-based"
+          }
+        }
+      },
+      {
+        "sha256": "53f7e57411eb30acc083ecc703eefc194a2db6e0c0a7dc7e0d4c338121baf5cd",
+        "marker": "parseText",
+        "result": [
+          {
+            "id": "scan",
+            "source": "scanning-parser",
+            "dictionary": null,
+            "index": 0,
+            "content": [
+              [
+                {
+                  "text": "行",
+                  "reading": "い",
+                  "headwords": [
+                    [
+                      {
+                        "term": "行く",
+                        "reading": "いく",
+                        "sources": [
+                          {
+                            "originalText": "行く",
+                            "transformedText": "行く",
+                            "deinflectedText": "行く",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "行く",
+                        "reading": "ゆく",
+                        "sources": [
+                          {
+                            "originalText": "行く",
+                            "transformedText": "行く",
+                            "deinflectedText": "行く",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "text": "く",
+                  "reading": ""
+                }
+              ],
+              [
+                {
+                  "text": "もんか",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "もんか",
+                        "reading": "もんか",
+                        "sources": [
+                          {
+                            "originalText": "もんか",
+                            "transformedText": "もんか",
+                            "deinflectedText": "もんか",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "門下",
+                        "reading": "もんか",
+                        "sources": [
+                          {
+                            "originalText": "もんか",
+                            "transformedText": "もんか",
+                            "deinflectedText": "もんか",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "紋菓",
+                        "reading": "もんか",
+                        "sources": [
+                          {
+                            "originalText": "もんか",
+                            "transformedText": "もんか",
+                            "deinflectedText": "もんか",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "e70e5cc6b26b0bb5fb4c1dfe7e4e349388a3971dbd8f2bbc40de7235f5b3fa70",
+        "marker": "termsFind",
+        "result": [
+          {
+            "surface": "行く",
+            "reading": "いく",
+            "headword": "行く",
+            "headwordReading": "いく",
+            "startPos": 0,
+            "endPos": 2,
+            "isNameMatch": false,
+            "frequencyRank": 44,
+            "wordClasses": [
+              "v5"
+            ]
+          },
+          {
+            "surface": "もんか",
+            "reading": "もんか",
+            "headword": "もんか",
+            "headwordReading": "もんか",
+            "startPos": 2,
+            "endPos": 5,
+            "isNameMatch": false,
+            "frequencyRank": 132013
+          }
+        ]
+      },
+      {
+        "sha256": "5d079056bdf47128d8a404e853b3a1eb7b5c3d62129359e35ceb0be29963ace8",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "行く",
+            "reading": "いく",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 44,
+            "displayValue": "44",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "行く",
+            "reading": "いく",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 65,
+            "displayValue": "65㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "行く",
+            "reading": "いく",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 38,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "行く",
+            "reading": "いく",
+            "dictionary": "CC100",
+            "hasReading": false,
+            "frequency": 50649,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "行く",
+            "reading": "いく",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 64,
+            "displayValue": "64",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "行く",
+            "reading": "いく",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 199,
+            "displayValue": "199㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "もんか",
+            "reading": "もんか",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 132013,
+            "displayValue": "132013㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "もんか",
+            "reading": "もんか",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 205847,
+            "displayValue": "205847㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "もんか",
+            "reading": "もんか",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 69629,
+            "displayValue": "69629㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      }
+    ],
+    "mecab": {
+      "行くもんか": [
+        {
+          "word": "行く",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "五段・カ行促音便",
+          "inflectionForm": "基本形",
+          "headword": "行く",
+          "katakanaReading": "イク",
+          "pronunciation": "イク"
+        },
+        {
+          "word": "もん",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "非自立",
+          "pos3": "一般",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "もん",
+          "katakanaReading": "モン",
+          "pronunciation": "モン"
+        },
+        {
+          "word": "か",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "副助詞／並立助詞／終助詞",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "か",
+          "katakanaReading": "カ",
+          "pronunciation": "カ"
+        }
+      ]
+    }
+  },
+  "expected": {
+    "tokens": [
+      {
+        "surface": "行く",
+        "reading": "いく",
+        "headword": "行く",
+        "startPos": 0,
+        "endPos": 2,
+        "partOfSpeech": "verb",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "いく",
+        "pos1": "動詞",
+        "pos2": "自立",
+        "pos3": "*",
+        "frequencyRank": 44
+      },
+      {
+        "surface": "もんか",
+        "reading": "もんか",
+        "headword": "もんか",
+        "startPos": 2,
+        "endPos": 5,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "もんか",
+        "pos1": "名詞|助詞",
+        "pos2": "非自立|副助詞／並立助詞／終助詞",
+        "pos3": "一般|*"
+      }
+    ]
+  }
+}

--- a/src/core/services/tokenizer/__fixtures__/golden/nplusone-single-unknown.json
+++ b/src/core/services/tokenizer/__fixtures__/golden/nplusone-single-unknown.json
@@ -1,0 +1,11255 @@
+{
+  "name": "nplusone-single-unknown",
+  "description": "single unknown content word in a known sentence becomes the N+1 target",
+  "recordedAt": "2026-07-11T00:50:02.057Z",
+  "input": {
+    "text": "私は新しい辞書を買った"
+  },
+  "config": {
+    "knownWords": [
+      "私",
+      "新しい",
+      "買う"
+    ]
+  },
+  "recording": {
+    "messages": [
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "parseText",
+        "params": {
+          "text": "私は新しい辞書を買った",
+          "optionsContext": {
+            "index": 0
+          },
+          "scanLength": 21,
+          "useInternalParser": true,
+          "useMecabParser": false
+        },
+        "response": {
+          "result": [
+            {
+              "id": "scan",
+              "source": "scanning-parser",
+              "dictionary": null,
+              "index": 0,
+              "content": [
+                [
+                  {
+                    "text": "私",
+                    "reading": "わたし",
+                    "headwords": [
+                      [
+                        {
+                          "term": "私",
+                          "reading": "わたし",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "あたし",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "あたくし",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "し",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "わて",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "あたい",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "あて",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "わたくし",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "わい",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "わたい",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "わっち",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "あっし",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "わらわ",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "わっし",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "わちき",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "私",
+                          "reading": "わし",
+                          "sources": [
+                            {
+                              "originalText": "私",
+                              "transformedText": "私",
+                              "deinflectedText": "私",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "は",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "は",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "は",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "は",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "刃",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "歯",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "派",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "葉",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "羽",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "波",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "破",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "覇",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "翳",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "齒",
+                          "reading": "は",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "は",
+                              "deinflectedText": "は",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "ハ",
+                          "reading": "ハ",
+                          "sources": [
+                            {
+                              "originalText": "は",
+                              "transformedText": "ハ",
+                              "deinflectedText": "ハ",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "新",
+                    "reading": "あたら",
+                    "headwords": [
+                      [
+                        {
+                          "term": "新しい",
+                          "reading": "あたらしい",
+                          "sources": [
+                            {
+                              "originalText": "新しい",
+                              "transformedText": "新しい",
+                              "deinflectedText": "新しい",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "text": "しい",
+                    "reading": ""
+                  }
+                ],
+                [
+                  {
+                    "text": "辞書",
+                    "reading": "じしょ",
+                    "headwords": [
+                      [
+                        {
+                          "term": "辞書",
+                          "reading": "じしょ",
+                          "sources": [
+                            {
+                              "originalText": "辞書",
+                              "transformedText": "辞書",
+                              "deinflectedText": "辞書",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "辞書",
+                          "reading": "じしょ",
+                          "sources": [
+                            {
+                              "originalText": "辞書",
+                              "transformedText": "辞書",
+                              "deinflectedText": "辞書",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "を",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "を",
+                          "reading": "を",
+                          "sources": [
+                            {
+                              "originalText": "を",
+                              "transformedText": "を",
+                              "deinflectedText": "を",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "買",
+                    "reading": "か",
+                    "headwords": [
+                      [
+                        {
+                          "term": "買う",
+                          "reading": "かう",
+                          "sources": [
+                            {
+                              "originalText": "買った",
+                              "transformedText": "買った",
+                              "deinflectedText": "買う",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "text": "った",
+                    "reading": ""
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "私は新しい辞書を買った",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "わたし",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "32",
+                    "displayValueParsed": false,
+                    "frequency": 32,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1308㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1308,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30",
+                    "displayValueParsed": false,
+                    "frequency": 30,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2072㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2072,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1312,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "あたし",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3008㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3008,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "176301",
+                    "displayValueParsed": false,
+                    "frequency": 176301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1744㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1744,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "79954",
+                    "displayValueParsed": false,
+                    "frequency": 79954,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "あたくし",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "35371㋕",
+                    "displayValueParsed": false,
+                    "frequency": 35371,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "26101",
+                    "displayValueParsed": false,
+                    "frequency": 26101,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 42850,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "わて",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "あたい",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "あて",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "わたくし",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3050㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3050,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "28801",
+                    "displayValueParsed": false,
+                    "frequency": 28801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4802㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4802,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 58,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "わい",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "わたい",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "わっち",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "あっし",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15713㋕",
+                    "displayValueParsed": false,
+                    "frequency": 15713,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "291201",
+                    "displayValueParsed": false,
+                    "frequency": 291201,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "わらわ",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "わっし",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "わちき",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "わし",
+                    "sources": [
+                      {
+                        "originalText": "私",
+                        "transformedText": "私",
+                        "deinflectedText": "私",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3093㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3093,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "175701",
+                    "displayValueParsed": false,
+                    "frequency": 175701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "は新しい辞書を買った",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "は",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 7,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "刃",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3237",
+                    "displayValueParsed": false,
+                    "frequency": 3237,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3789",
+                    "displayValueParsed": false,
+                    "frequency": 3789,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11385,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "歯",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2347",
+                    "displayValueParsed": false,
+                    "frequency": 2347,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2970",
+                    "displayValueParsed": false,
+                    "frequency": 2970,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1308,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "派",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2266",
+                    "displayValueParsed": false,
+                    "frequency": 2266,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2666",
+                    "displayValueParsed": false,
+                    "frequency": 2666,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3376,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "葉",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2636",
+                    "displayValueParsed": false,
+                    "frequency": 2636,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4595",
+                    "displayValueParsed": false,
+                    "frequency": 4595,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5958㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5958,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3910,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 141627,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 98,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "羽",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 122375,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "波",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11901",
+                    "displayValueParsed": false,
+                    "frequency": 11901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12771",
+                    "displayValueParsed": false,
+                    "frequency": 12771,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 12312,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 149753,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "破",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "13055",
+                    "displayValueParsed": false,
+                    "frequency": 13055,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17456",
+                    "displayValueParsed": false,
+                    "frequency": 17456,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24656,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "覇",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "25011",
+                    "displayValueParsed": false,
+                    "frequency": 25011,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "28696",
+                    "displayValueParsed": false,
+                    "frequency": 28696,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46146,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -7,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "翳",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "齒",
+                    "reading": "は",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "は",
+                        "deinflectedText": "は",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "222949",
+                    "displayValueParsed": false,
+                    "frequency": 222949,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "151659",
+                    "displayValueParsed": false,
+                    "frequency": 151659,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ハ",
+                    "reading": "ハ",
+                    "sources": [
+                      {
+                        "originalText": "は",
+                        "transformedText": "ハ",
+                        "deinflectedText": "ハ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9384㋕",
+                    "displayValueParsed": false,
+                    "frequency": 9384,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "26894㋕",
+                    "displayValueParsed": false,
+                    "frequency": 26894,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "69082㋕",
+                    "displayValueParsed": false,
+                    "frequency": 69082,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "26421㋕",
+                    "displayValueParsed": false,
+                    "frequency": 26421,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26136,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "新しい辞書を買った",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "新しい",
+                    "reading": "あたらしい",
+                    "sources": [
+                      {
+                        "originalText": "新しい",
+                        "transformedText": "新しい",
+                        "deinflectedText": "新しい",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "373",
+                    "displayValueParsed": false,
+                    "frequency": 373,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "32084㋕",
+                    "displayValueParsed": false,
+                    "frequency": 32084,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "360",
+                    "displayValueParsed": false,
+                    "frequency": 360,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "34337㋕",
+                    "displayValueParsed": false,
+                    "frequency": 34337,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 314,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "新",
+                    "reading": "しん",
+                    "sources": [
+                      {
+                        "originalText": "新",
+                        "transformedText": "新",
+                        "deinflectedText": "新",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1244",
+                    "displayValueParsed": false,
+                    "frequency": 1244,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1892",
+                    "displayValueParsed": false,
+                    "frequency": 1892,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "200753㋕",
+                    "displayValueParsed": false,
+                    "frequency": 200753,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1105,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 137089,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "新",
+                    "reading": "さら",
+                    "sources": [
+                      {
+                        "originalText": "新",
+                        "transformedText": "新",
+                        "deinflectedText": "新",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27902",
+                    "displayValueParsed": false,
+                    "frequency": 27902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "77696㋕",
+                    "displayValueParsed": false,
+                    "frequency": 77696,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11990㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11990,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "286883",
+                    "displayValueParsed": false,
+                    "frequency": 286883,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 98005,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 137089,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "新",
+                    "reading": "あら",
+                    "sources": [
+                      {
+                        "originalText": "新",
+                        "transformedText": "新",
+                        "deinflectedText": "新",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 137089,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -3,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "新",
+                    "reading": "にい",
+                    "sources": [
+                      {
+                        "originalText": "新",
+                        "transformedText": "新",
+                        "deinflectedText": "新",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14091㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14091,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 137089,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "しい辞書を買った",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "しい",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "77224㋕",
+                    "displayValueParsed": false,
+                    "frequency": 77224,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12010㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12010,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 32923,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四位",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34969",
+                    "displayValueParsed": false,
+                    "frequency": 34969,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "46869",
+                    "displayValueParsed": false,
+                    "frequency": 46869,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 61397,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四囲",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "53302",
+                    "displayValueParsed": false,
+                    "frequency": 53302,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "77224㋕",
+                    "displayValueParsed": false,
+                    "frequency": 77224,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "84976",
+                    "displayValueParsed": false,
+                    "frequency": 84976,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 105255,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四夷",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "207473",
+                    "displayValueParsed": false,
+                    "frequency": 207473,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "245837",
+                    "displayValueParsed": false,
+                    "frequency": 245837,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 129290,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四維",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "234112",
+                    "displayValueParsed": false,
+                    "frequency": 234112,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "300815",
+                    "displayValueParsed": false,
+                    "frequency": 300815,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 135793,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "尸位",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "思惟",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "37326",
+                    "displayValueParsed": false,
+                    "frequency": 37326,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "70352",
+                    "displayValueParsed": false,
+                    "frequency": 70352,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 48863,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "恣意",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "81551",
+                    "displayValueParsed": false,
+                    "frequency": 81551,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "97944",
+                    "displayValueParsed": false,
+                    "frequency": 97944,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 38003,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "施為",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "245204",
+                    "displayValueParsed": false,
+                    "frequency": 245204,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "旨意",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "206422",
+                    "displayValueParsed": false,
+                    "frequency": 206422,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "215165",
+                    "displayValueParsed": false,
+                    "frequency": 215165,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 82915,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私意",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "152144",
+                    "displayValueParsed": false,
+                    "frequency": 152144,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "141217",
+                    "displayValueParsed": false,
+                    "frequency": 141217,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 114175,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "肢位",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "355605",
+                    "displayValueParsed": false,
+                    "frequency": 355605,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "詩意",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "280135",
+                    "displayValueParsed": false,
+                    "frequency": 280135,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "286883",
+                    "displayValueParsed": false,
+                    "frequency": 286883,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 140831,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "椎",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "37416",
+                    "displayValueParsed": false,
+                    "frequency": 37416,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "48565",
+                    "displayValueParsed": false,
+                    "frequency": 48565,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 45621,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "示威",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23200㋕",
+                    "displayValueParsed": false,
+                    "frequency": 23200,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "紫衣",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 100705,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "緇衣",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "肆意",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "242901",
+                    "displayValueParsed": false,
+                    "frequency": 242901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -105,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "尿",
+                    "reading": "しい",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12010㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12010,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "強いる",
+                    "reading": "しいる",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しいる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5629",
+                    "displayValueParsed": false,
+                    "frequency": 5629,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6600㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6600,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4692",
+                    "displayValueParsed": false,
+                    "frequency": 4692,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "18176㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18176,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6742,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "誣いる",
+                    "reading": "しいる",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "しい",
+                        "deinflectedText": "しいる",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "124077㋕",
+                    "displayValueParsed": false,
+                    "frequency": 124077,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "219204",
+                    "displayValueParsed": false,
+                    "frequency": 219204,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "213904",
+                    "displayValueParsed": false,
+                    "frequency": 213904,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158616,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "シイ",
+                    "reading": "シイ",
+                    "sources": [
+                      {
+                        "originalText": "しい",
+                        "transformedText": "シイ",
+                        "deinflectedText": "シイ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "189107㋕",
+                    "displayValueParsed": false,
+                    "frequency": 189107,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "105634㋕",
+                    "displayValueParsed": false,
+                    "frequency": 105634,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "し",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "58㋕",
+                    "displayValueParsed": false,
+                    "frequency": 58,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40㋕",
+                    "displayValueParsed": false,
+                    "frequency": 40,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 107,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "史",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10409",
+                    "displayValueParsed": false,
+                    "frequency": 10409,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14354",
+                    "displayValueParsed": false,
+                    "frequency": 14354,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5055,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 148554,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2539",
+                    "displayValueParsed": false,
+                    "frequency": 2539,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10427㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10427,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11632,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "市",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2466",
+                    "displayValueParsed": false,
+                    "frequency": 2466,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5353",
+                    "displayValueParsed": false,
+                    "frequency": 5353,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36419㋕",
+                    "displayValueParsed": false,
+                    "frequency": 36419,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1754,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "死",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "909",
+                    "displayValueParsed": false,
+                    "frequency": 909,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1050",
+                    "displayValueParsed": false,
+                    "frequency": 1050,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2640,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "氏",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2076",
+                    "displayValueParsed": false,
+                    "frequency": 2076,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3723",
+                    "displayValueParsed": false,
+                    "frequency": 3723,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "128121㋕",
+                    "displayValueParsed": false,
+                    "frequency": 128121,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 754,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "詩",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6043",
+                    "displayValueParsed": false,
+                    "frequency": 6043,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10033",
+                    "displayValueParsed": false,
+                    "frequency": 10033,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5328,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "誌",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14324",
+                    "displayValueParsed": false,
+                    "frequency": 14324,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13547",
+                    "displayValueParsed": false,
+                    "frequency": 13547,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "137640㋕",
+                    "displayValueParsed": false,
+                    "frequency": 137640,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4850,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "４",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10427㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10427,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "264167",
+                    "displayValueParsed": false,
+                    "frequency": 264167,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "巳",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "い辞書を買った",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "い",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亥",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47280",
+                    "displayValueParsed": false,
+                    "frequency": 47280,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "56084",
+                    "displayValueParsed": false,
+                    "frequency": 56084,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46249,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伊",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14364",
+                    "displayValueParsed": false,
+                    "frequency": 14364,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30166",
+                    "displayValueParsed": false,
+                    "frequency": 30166,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "位",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4902",
+                    "displayValueParsed": false,
+                    "frequency": 4902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4817",
+                    "displayValueParsed": false,
+                    "frequency": 4817,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 967,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134715,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15864",
+                    "displayValueParsed": false,
+                    "frequency": 15864,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19720",
+                    "displayValueParsed": false,
+                    "frequency": 19720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5024,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胃",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4320",
+                    "displayValueParsed": false,
+                    "frequency": 4320,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4265",
+                    "displayValueParsed": false,
+                    "frequency": 4265,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4335,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 94,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 92,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伍",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "井",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6111",
+                    "displayValueParsed": false,
+                    "frequency": 6111,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19958",
+                    "displayValueParsed": false,
+                    "frequency": 19958,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18798,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "偉",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "42742",
+                    "displayValueParsed": false,
+                    "frequency": 42742,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40683",
+                    "displayValueParsed": false,
+                    "frequency": 40683,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65831㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62518,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夷",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75303",
+                    "displayValueParsed": false,
+                    "frequency": 75303,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 85253,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "委",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "42381",
+                    "displayValueParsed": false,
+                    "frequency": 42381,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23040,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "威",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27002",
+                    "displayValueParsed": false,
+                    "frequency": 27002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36921",
+                    "displayValueParsed": false,
+                    "frequency": 36921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30452,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126695,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45301",
+                    "displayValueParsed": false,
+                    "frequency": 45301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236493",
+                    "displayValueParsed": false,
+                    "frequency": 236493,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "彙",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "105649",
+                    "displayValueParsed": false,
+                    "frequency": 105649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160667",
+                    "displayValueParsed": false,
+                    "frequency": 160667,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "意",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4338",
+                    "displayValueParsed": false,
+                    "frequency": 4338,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4069",
+                    "displayValueParsed": false,
+                    "frequency": 4069,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5912,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "易",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 138689,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "汝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "猪",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "118901",
+                    "displayValueParsed": false,
+                    "frequency": 118901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "異",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14852",
+                    "displayValueParsed": false,
+                    "frequency": 14852,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15812",
+                    "displayValueParsed": false,
+                    "frequency": 15812,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4892,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胆",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145167,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "藺",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "94214",
+                    "displayValueParsed": false,
+                    "frequency": 94214,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "138991",
+                    "displayValueParsed": false,
+                    "frequency": 138991,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 99348,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "衣",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24121,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132574,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豬",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "200568",
+                    "displayValueParsed": false,
+                    "frequency": 200568,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "196521",
+                    "displayValueParsed": false,
+                    "frequency": 196521,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豕",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -6,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "緯",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 96278,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "寝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "堰",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -106,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５０",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -107,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五十",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -108,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五〇",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 121488,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "辞書を買った",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "辞書",
+                    "reading": "じしょ",
+                    "sources": [
+                      {
+                        "originalText": "辞書",
+                        "transformedText": "辞書",
+                        "deinflectedText": "辞書",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12259",
+                    "displayValueParsed": false,
+                    "frequency": 12259,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "199222㋕",
+                    "displayValueParsed": false,
+                    "frequency": 199222,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11830",
+                    "displayValueParsed": false,
+                    "frequency": 11830,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "126592㋕",
+                    "displayValueParsed": false,
+                    "frequency": 126592,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5516,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 159369,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "辞",
+                    "reading": "じ",
+                    "sources": [
+                      {
+                        "originalText": "辞",
+                        "transformedText": "辞",
+                        "deinflectedText": "辞",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "33002",
+                    "displayValueParsed": false,
+                    "frequency": 33002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "37563",
+                    "displayValueParsed": false,
+                    "frequency": 37563,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 39525,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "辞",
+                    "reading": "ことば",
+                    "sources": [
+                      {
+                        "originalText": "辞",
+                        "transformedText": "辞",
+                        "deinflectedText": "辞",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9678㋕",
+                    "displayValueParsed": false,
+                    "frequency": 9678,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "186102",
+                    "displayValueParsed": false,
+                    "frequency": 186102,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17620㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17620,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "121040",
+                    "displayValueParsed": false,
+                    "frequency": 121040,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "書を買った",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "書",
+                    "reading": "ふみ",
+                    "sources": [
+                      {
+                        "originalText": "書",
+                        "transformedText": "書",
+                        "deinflectedText": "書",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "191801",
+                    "displayValueParsed": false,
+                    "frequency": 191801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17617",
+                    "displayValueParsed": false,
+                    "frequency": 17617,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25707㋕",
+                    "displayValueParsed": false,
+                    "frequency": 25707,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 151123,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "書",
+                    "reading": "しょ",
+                    "sources": [
+                      {
+                        "originalText": "書",
+                        "transformedText": "書",
+                        "deinflectedText": "書",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3701",
+                    "displayValueParsed": false,
+                    "frequency": 3701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4429㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4429,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5554",
+                    "displayValueParsed": false,
+                    "frequency": 5554,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "22706㋕",
+                    "displayValueParsed": false,
+                    "frequency": 22706,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1896,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 151123,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "を買った",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "を",
+                    "reading": "を",
+                    "sources": [
+                      {
+                        "originalText": "を",
+                        "transformedText": "を",
+                        "deinflectedText": "を",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "買った",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "買う",
+                    "reading": "かう",
+                    "sources": [
+                      {
+                        "originalText": "買った",
+                        "transformedText": "買った",
+                        "deinflectedText": "買う",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "309",
+                    "displayValueParsed": false,
+                    "frequency": 309,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4585㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4585,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "293",
+                    "displayValueParsed": false,
+                    "frequency": 293,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2617㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2617,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 212,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "った",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [],
+            "originalTextLength": 0
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "た",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "た",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "他",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 163,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 113090,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "多",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5815",
+                    "displayValueParsed": false,
+                    "frequency": 5815,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8609",
+                    "displayValueParsed": false,
+                    "frequency": 8609,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4965,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126617,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "田",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2236",
+                    "displayValueParsed": false,
+                    "frequency": 2236,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10070",
+                    "displayValueParsed": false,
+                    "frequency": 10070,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 20971,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 148593,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "咫",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "私",
+              "reading": "わたし"
+            },
+            {
+              "term": "は",
+              "reading": "は"
+            },
+            {
+              "term": "新しい",
+              "reading": "あたらしい"
+            },
+            {
+              "term": "辞書",
+              "reading": "じしょ"
+            },
+            {
+              "term": "を",
+              "reading": "を"
+            },
+            {
+              "term": "買う",
+              "reading": "かった"
+            },
+            {
+              "term": "買った",
+              "reading": "かった"
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "私",
+              "reading": "わたし",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 32,
+              "displayValue": "32",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "私",
+              "reading": "わたし",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 1308,
+              "displayValue": "1308㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "私",
+              "reading": "わたし",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 1312,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "私",
+              "reading": "わたし",
+              "dictionary": "CC100",
+              "hasReading": false,
+              "frequency": 150240,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "私",
+              "reading": "わたし",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 30,
+              "displayValue": "30",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "私",
+              "reading": "わたし",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 2072,
+              "displayValue": "2072㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "は",
+              "reading": "は",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 2,
+              "displayValue": "2㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "は",
+              "reading": "は",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 1501,
+              "displayValue": "1501㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "は",
+              "reading": "は",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 7,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "は",
+              "reading": "は",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 2,
+              "displayValue": "2㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "新しい",
+              "reading": "あたらしい",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 373,
+              "displayValue": "373",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "新しい",
+              "reading": "あたらしい",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 32084,
+              "displayValue": "32084㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "新しい",
+              "reading": "あたらしい",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 314,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "新しい",
+              "reading": "あたらしい",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 360,
+              "displayValue": "360",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "新しい",
+              "reading": "あたらしい",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 34337,
+              "displayValue": "34337㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "辞書",
+              "reading": "じしょ",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 12259,
+              "displayValue": "12259",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "辞書",
+              "reading": "じしょ",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 199222,
+              "displayValue": "199222㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "辞書",
+              "reading": "じしょ",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 5516,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "辞書",
+              "reading": "じしょ",
+              "dictionary": "CC100",
+              "hasReading": false,
+              "frequency": 159369,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "辞書",
+              "reading": "じしょ",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 11830,
+              "displayValue": "11830",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "辞書",
+              "reading": "じしょ",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 126592,
+              "displayValue": "126592㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "を",
+              "reading": "を",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 4,
+              "displayValue": "4㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "を",
+              "reading": "を",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 5,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "を",
+              "reading": "を",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 4,
+              "displayValue": "4㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "買う",
+              "reading": null
+            },
+            {
+              "term": "買った",
+              "reading": null
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "買う",
+              "reading": "かう",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 309,
+              "displayValue": "309",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "買う",
+              "reading": "かう",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 4585,
+              "displayValue": "4585㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "買う",
+              "reading": "かう",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 212,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "買う",
+              "reading": "かう",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 293,
+              "displayValue": "293",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "買う",
+              "reading": "かう",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 2617,
+              "displayValue": "2617㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      }
+    ],
+    "scripts": [
+      {
+        "sha256": "fb64f047eb0494f136bb92311df43c5318873298fe3efad6bfa82e5d531a93e1",
+        "marker": "optionsGetFull",
+        "result": {
+          "profileIndex": 0,
+          "scanLength": 21,
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ],
+          "dictionaryPriorityByName": {
+            "Jitendex.org [2026-03-05]": 0,
+            "日本語文法辞典(全集)": 1,
+            "JPDBv2㋕": 2,
+            "Jiten": 3,
+            "CC100": 4,
+            "実用日本語表現辞典": 5,
+            "NHK": 6,
+            "SubMiner Character Dictionary": 7
+          },
+          "dictionaryFrequencyModeByName": {
+            "JPDBv2㋕": "rank-based",
+            "Jiten": "rank-based"
+          }
+        }
+      },
+      {
+        "sha256": "54f83f1d59df6fc06210db2c14ac47a19d8827a20f1e0dab617d536612cb95af",
+        "marker": "parseText",
+        "result": [
+          {
+            "id": "scan",
+            "source": "scanning-parser",
+            "dictionary": null,
+            "index": 0,
+            "content": [
+              [
+                {
+                  "text": "私",
+                  "reading": "わたし",
+                  "headwords": [
+                    [
+                      {
+                        "term": "私",
+                        "reading": "わたし",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "あたし",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "あたくし",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "し",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "わて",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "あたい",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "あて",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "わたくし",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "わい",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "わたい",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "わっち",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "あっし",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "わらわ",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "わっし",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "わちき",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "私",
+                        "reading": "わし",
+                        "sources": [
+                          {
+                            "originalText": "私",
+                            "transformedText": "私",
+                            "deinflectedText": "私",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "は",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "は",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "は",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "は",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "刃",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "歯",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "派",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "葉",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "羽",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "波",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "破",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "覇",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "翳",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "齒",
+                        "reading": "は",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "は",
+                            "deinflectedText": "は",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "ハ",
+                        "reading": "ハ",
+                        "sources": [
+                          {
+                            "originalText": "は",
+                            "transformedText": "ハ",
+                            "deinflectedText": "ハ",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "新",
+                  "reading": "あたら",
+                  "headwords": [
+                    [
+                      {
+                        "term": "新しい",
+                        "reading": "あたらしい",
+                        "sources": [
+                          {
+                            "originalText": "新しい",
+                            "transformedText": "新しい",
+                            "deinflectedText": "新しい",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "text": "しい",
+                  "reading": ""
+                }
+              ],
+              [
+                {
+                  "text": "辞書",
+                  "reading": "じしょ",
+                  "headwords": [
+                    [
+                      {
+                        "term": "辞書",
+                        "reading": "じしょ",
+                        "sources": [
+                          {
+                            "originalText": "辞書",
+                            "transformedText": "辞書",
+                            "deinflectedText": "辞書",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "辞書",
+                        "reading": "じしょ",
+                        "sources": [
+                          {
+                            "originalText": "辞書",
+                            "transformedText": "辞書",
+                            "deinflectedText": "辞書",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "を",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "を",
+                        "reading": "を",
+                        "sources": [
+                          {
+                            "originalText": "を",
+                            "transformedText": "を",
+                            "deinflectedText": "を",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "買",
+                  "reading": "か",
+                  "headwords": [
+                    [
+                      {
+                        "term": "買う",
+                        "reading": "かう",
+                        "sources": [
+                          {
+                            "originalText": "買った",
+                            "transformedText": "買った",
+                            "deinflectedText": "買う",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "text": "った",
+                  "reading": ""
+                }
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "9fcf44f8b93696fc56f86d438a17405776b4a103740e752cfa940ed7eb729d4c",
+        "marker": "termsFind",
+        "result": [
+          {
+            "surface": "私",
+            "reading": "わたし",
+            "headword": "私",
+            "headwordReading": "わたし",
+            "startPos": 0,
+            "endPos": 1,
+            "isNameMatch": false,
+            "frequencyRank": 32
+          },
+          {
+            "surface": "は",
+            "reading": "は",
+            "headword": "は",
+            "headwordReading": "は",
+            "startPos": 1,
+            "endPos": 2,
+            "isNameMatch": false,
+            "frequencyRank": 2
+          },
+          {
+            "surface": "新しい",
+            "reading": "あたらしい",
+            "headword": "新しい",
+            "headwordReading": "あたらしい",
+            "startPos": 2,
+            "endPos": 5,
+            "isNameMatch": false,
+            "frequencyRank": 373,
+            "wordClasses": [
+              "adj-i"
+            ]
+          },
+          {
+            "surface": "辞書",
+            "reading": "じしょ",
+            "headword": "辞書",
+            "headwordReading": "じしょ",
+            "startPos": 5,
+            "endPos": 7,
+            "isNameMatch": false,
+            "frequencyRank": 12259
+          },
+          {
+            "surface": "を",
+            "reading": "を",
+            "headword": "を",
+            "headwordReading": "を",
+            "startPos": 7,
+            "endPos": 8,
+            "isNameMatch": false,
+            "frequencyRank": 4
+          },
+          {
+            "surface": "買った",
+            "reading": "かった",
+            "headword": "買う",
+            "headwordReading": "かう",
+            "startPos": 8,
+            "endPos": 11,
+            "isNameMatch": false,
+            "frequencyRank": 309,
+            "wordClasses": [
+              "v5"
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "152c4970d5b07eb7c5e84c59da6869df7d20a3fdbe421ea76563b78c12f325cd",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "私",
+            "reading": "わたし",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 32,
+            "displayValue": "32",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "私",
+            "reading": "わたし",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 1308,
+            "displayValue": "1308㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "私",
+            "reading": "わたし",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 1312,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "私",
+            "reading": "わたし",
+            "dictionary": "CC100",
+            "hasReading": false,
+            "frequency": 150240,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "私",
+            "reading": "わたし",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 30,
+            "displayValue": "30",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "私",
+            "reading": "わたし",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 2072,
+            "displayValue": "2072㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "は",
+            "reading": "は",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 2,
+            "displayValue": "2㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "は",
+            "reading": "は",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 1501,
+            "displayValue": "1501㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "は",
+            "reading": "は",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 7,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "は",
+            "reading": "は",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 2,
+            "displayValue": "2㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "新しい",
+            "reading": "あたらしい",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 373,
+            "displayValue": "373",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "新しい",
+            "reading": "あたらしい",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 32084,
+            "displayValue": "32084㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "新しい",
+            "reading": "あたらしい",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 314,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "新しい",
+            "reading": "あたらしい",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 360,
+            "displayValue": "360",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "新しい",
+            "reading": "あたらしい",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 34337,
+            "displayValue": "34337㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "辞書",
+            "reading": "じしょ",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 12259,
+            "displayValue": "12259",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "辞書",
+            "reading": "じしょ",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 199222,
+            "displayValue": "199222㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "辞書",
+            "reading": "じしょ",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 5516,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "辞書",
+            "reading": "じしょ",
+            "dictionary": "CC100",
+            "hasReading": false,
+            "frequency": 159369,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "辞書",
+            "reading": "じしょ",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 11830,
+            "displayValue": "11830",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "辞書",
+            "reading": "じしょ",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 126592,
+            "displayValue": "126592㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "を",
+            "reading": "を",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 4,
+            "displayValue": "4㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "を",
+            "reading": "を",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 5,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "を",
+            "reading": "を",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 4,
+            "displayValue": "4㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      },
+      {
+        "sha256": "66e6f04d41470bd10f5ca51e831fd29c865d5963f46636ae2f33e91017458952",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "買う",
+            "reading": "かう",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 309,
+            "displayValue": "309",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "買う",
+            "reading": "かう",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 4585,
+            "displayValue": "4585㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "買う",
+            "reading": "かう",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 212,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "買う",
+            "reading": "かう",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 293,
+            "displayValue": "293",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "買う",
+            "reading": "かう",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 2617,
+            "displayValue": "2617㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      }
+    ],
+    "mecab": {
+      "私は新しい辞書を買った": [
+        {
+          "word": "私",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "代名詞",
+          "pos3": "一般",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "私",
+          "katakanaReading": "ワタシ",
+          "pronunciation": "ワタシ"
+        },
+        {
+          "word": "は",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "係助詞",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "は",
+          "katakanaReading": "ハ",
+          "pronunciation": "ワ"
+        },
+        {
+          "word": "新しい",
+          "partOfSpeech": "i_adjective",
+          "pos1": "形容詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "形容詞・イ段",
+          "inflectionForm": "基本形",
+          "headword": "新しい",
+          "katakanaReading": "アタラシイ",
+          "pronunciation": "アタラシイ"
+        },
+        {
+          "word": "辞書",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "一般",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "辞書",
+          "katakanaReading": "ジショ",
+          "pronunciation": "ジショ"
+        },
+        {
+          "word": "を",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "格助詞",
+          "pos3": "一般",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "を",
+          "katakanaReading": "ヲ",
+          "pronunciation": "ヲ"
+        },
+        {
+          "word": "買っ",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "五段・ワ行促音便",
+          "inflectionForm": "連用タ接続",
+          "headword": "買う",
+          "katakanaReading": "カッ",
+          "pronunciation": "カッ"
+        },
+        {
+          "word": "た",
+          "partOfSpeech": "bound_auxiliary",
+          "pos1": "助動詞",
+          "pos2": "*",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "特殊・タ",
+          "inflectionForm": "基本形",
+          "headword": "た",
+          "katakanaReading": "タ",
+          "pronunciation": "タ"
+        }
+      ]
+    }
+  },
+  "expected": {
+    "tokens": [
+      {
+        "surface": "私",
+        "reading": "わたし",
+        "headword": "私",
+        "startPos": 0,
+        "endPos": 1,
+        "partOfSpeech": "other",
+        "isKnown": true,
+        "isNPlusOneTarget": false,
+        "headwordReading": "わたし",
+        "pos1": "名詞",
+        "pos2": "代名詞",
+        "pos3": "一般",
+        "frequencyRank": 32
+      },
+      {
+        "surface": "は",
+        "reading": "は",
+        "headword": "は",
+        "startPos": 1,
+        "endPos": 2,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "は",
+        "pos1": "助詞",
+        "pos2": "係助詞",
+        "pos3": "*"
+      },
+      {
+        "surface": "新しい",
+        "reading": "あたらしい",
+        "headword": "新しい",
+        "startPos": 2,
+        "endPos": 5,
+        "partOfSpeech": "i_adjective",
+        "isKnown": true,
+        "isNPlusOneTarget": false,
+        "headwordReading": "あたらしい",
+        "pos1": "形容詞",
+        "pos2": "自立",
+        "pos3": "*",
+        "frequencyRank": 373
+      },
+      {
+        "surface": "辞書",
+        "reading": "じしょ",
+        "headword": "辞書",
+        "startPos": 5,
+        "endPos": 7,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": true,
+        "headwordReading": "じしょ",
+        "pos1": "名詞",
+        "pos2": "一般",
+        "pos3": "*",
+        "frequencyRank": 12259
+      },
+      {
+        "surface": "を",
+        "reading": "を",
+        "headword": "を",
+        "startPos": 7,
+        "endPos": 8,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "を",
+        "pos1": "助詞",
+        "pos2": "格助詞",
+        "pos3": "一般"
+      },
+      {
+        "surface": "買った",
+        "reading": "かった",
+        "headword": "買う",
+        "startPos": 8,
+        "endPos": 11,
+        "partOfSpeech": "verb",
+        "isKnown": true,
+        "isNPlusOneTarget": false,
+        "headwordReading": "かう",
+        "pos1": "動詞",
+        "pos2": "自立",
+        "pos3": "*",
+        "frequencyRank": 309
+      }
+    ]
+  }
+}

--- a/src/core/services/tokenizer/__fixtures__/golden/ordinal-prefix-noun.json
+++ b/src/core/services/tokenizer/__fixtures__/golden/ordinal-prefix-noun.json
@@ -1,0 +1,2999 @@
+{
+  "name": "ordinal-prefix-noun",
+  "description": "ordinal dai-prefix noun keeps frequency annotation",
+  "recordedAt": "2026-07-11T00:50:24.889Z",
+  "input": {
+    "text": "第三話を見た"
+  },
+  "config": {},
+  "recording": {
+    "messages": [
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "parseText",
+        "params": {
+          "text": "第三話を見た",
+          "optionsContext": {
+            "index": 0
+          },
+          "scanLength": 21,
+          "useInternalParser": true,
+          "useMecabParser": false
+        },
+        "response": {
+          "result": [
+            {
+              "id": "scan",
+              "source": "scanning-parser",
+              "dictionary": null,
+              "index": 0,
+              "content": [
+                [
+                  {
+                    "text": "第三",
+                    "reading": "だいさん",
+                    "headwords": [
+                      [
+                        {
+                          "term": "第三",
+                          "reading": "だいさん",
+                          "sources": [
+                            {
+                              "originalText": "第三",
+                              "transformedText": "第三",
+                              "deinflectedText": "第三",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "話",
+                    "reading": "はなし",
+                    "headwords": [
+                      [
+                        {
+                          "term": "話",
+                          "reading": "はなし",
+                          "sources": [
+                            {
+                              "originalText": "話",
+                              "transformedText": "話",
+                              "deinflectedText": "話",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "話",
+                          "reading": "わ",
+                          "sources": [
+                            {
+                              "originalText": "話",
+                              "transformedText": "話",
+                              "deinflectedText": "話",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "を",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "を",
+                          "reading": "を",
+                          "sources": [
+                            {
+                              "originalText": "を",
+                              "transformedText": "を",
+                              "deinflectedText": "を",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "見",
+                    "reading": "み",
+                    "headwords": [
+                      [
+                        {
+                          "term": "見る",
+                          "reading": "みる",
+                          "sources": [
+                            {
+                              "originalText": "見た",
+                              "transformedText": "見た",
+                              "deinflectedText": "見る",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "text": "た",
+                    "reading": ""
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "第三話を見た",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "第三",
+                    "reading": "だいさん",
+                    "sources": [
+                      {
+                        "originalText": "第三",
+                        "transformedText": "第三",
+                        "deinflectedText": "第三",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3405",
+                    "displayValueParsed": false,
+                    "frequency": 3405,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4616",
+                    "displayValueParsed": false,
+                    "frequency": 4616,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "279165㋕",
+                    "displayValueParsed": false,
+                    "frequency": 279165,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 78695,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "第",
+                    "reading": "だい",
+                    "sources": [
+                      {
+                        "originalText": "第",
+                        "transformedText": "第",
+                        "deinflectedText": "第",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1568",
+                    "displayValueParsed": false,
+                    "frequency": 1568,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10601㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4044",
+                    "displayValueParsed": false,
+                    "frequency": 4044,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 30501,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 111,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "三話を見た",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "三",
+                    "reading": "さん",
+                    "sources": [
+                      {
+                        "originalText": "三",
+                        "transformedText": "三",
+                        "deinflectedText": "三",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "626",
+                    "displayValueParsed": false,
+                    "frequency": 626,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "85401㋕",
+                    "displayValueParsed": false,
+                    "frequency": 85401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1428",
+                    "displayValueParsed": false,
+                    "frequency": 1428,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5204㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5204,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 548,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 195,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "三",
+                    "reading": "み",
+                    "sources": [
+                      {
+                        "originalText": "三",
+                        "transformedText": "三",
+                        "deinflectedText": "三",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10892㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10892,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5629,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "三",
+                    "reading": "サン",
+                    "sources": [
+                      {
+                        "originalText": "三",
+                        "transformedText": "三",
+                        "deinflectedText": "三",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "話を見た",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "話",
+                    "reading": "はなし",
+                    "sources": [
+                      {
+                        "originalText": "話",
+                        "transformedText": "話",
+                        "deinflectedText": "話",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "95",
+                    "displayValueParsed": false,
+                    "frequency": 95,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22696㋕",
+                    "displayValueParsed": false,
+                    "frequency": 22696,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "103",
+                    "displayValueParsed": false,
+                    "frequency": 103,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "17535㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17535,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126356,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "話",
+                    "reading": "わ",
+                    "sources": [
+                      {
+                        "originalText": "話",
+                        "transformedText": "話",
+                        "deinflectedText": "話",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11001",
+                    "displayValueParsed": false,
+                    "frequency": 11001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6835",
+                    "displayValueParsed": false,
+                    "frequency": 6835,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11726,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126356,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "を見た",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "を",
+                    "reading": "を",
+                    "sources": [
+                      {
+                        "originalText": "を",
+                        "transformedText": "を",
+                        "deinflectedText": "を",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "見た",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-た",
+                        "description": "1. Indicates a reality that has happened in the past.\n2. Indicates the completion of an action.\n3. Indicates the confirmation of a matter.\n4. Indicates the speaker's confidence that the action will definitely be fulfilled.\n5. Indicates the events that occur before the main clause are represented as relative past.\n6. Indicates a mild imperative/command.\nUsage: Attach た to the continuative form (連用形) of verbs after euphonic change form, かった to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "見る",
+                    "reading": "みる",
+                    "sources": [
+                      {
+                        "originalText": "見た",
+                        "transformedText": "見た",
+                        "deinflectedText": "見る",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "36",
+                    "displayValueParsed": false,
+                    "frequency": 36,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "110㋕",
+                    "displayValueParsed": false,
+                    "frequency": 110,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "46",
+                    "displayValueParsed": false,
+                    "frequency": 46,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "895㋕",
+                    "displayValueParsed": false,
+                    "frequency": 895,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 33,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "見",
+                    "reading": "み",
+                    "sources": [
+                      {
+                        "originalText": "見",
+                        "transformedText": "見",
+                        "deinflectedText": "見",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6181",
+                    "displayValueParsed": false,
+                    "frequency": 6181,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11878",
+                    "displayValueParsed": false,
+                    "frequency": 11878,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "59864㋕",
+                    "displayValueParsed": false,
+                    "frequency": 59864,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11907,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 149713,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "見",
+                    "reading": "けん",
+                    "sources": [
+                      {
+                        "originalText": "見",
+                        "transformedText": "見",
+                        "deinflectedText": "見",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "28506",
+                    "displayValueParsed": false,
+                    "frequency": 28506,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 149713,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "た",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "た",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "他",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 163,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 113090,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "多",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5815",
+                    "displayValueParsed": false,
+                    "frequency": 5815,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8609",
+                    "displayValueParsed": false,
+                    "frequency": 8609,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4965,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126617,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "田",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2236",
+                    "displayValueParsed": false,
+                    "frequency": 2236,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10070",
+                    "displayValueParsed": false,
+                    "frequency": 10070,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 20971,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 148593,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "咫",
+                    "reading": "た",
+                    "sources": [
+                      {
+                        "originalText": "た",
+                        "transformedText": "た",
+                        "deinflectedText": "た",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "第三",
+              "reading": "だいさん"
+            },
+            {
+              "term": "話",
+              "reading": "はなし"
+            },
+            {
+              "term": "を",
+              "reading": "を"
+            },
+            {
+              "term": "見る",
+              "reading": "みた"
+            },
+            {
+              "term": "見た",
+              "reading": "みた"
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "第三",
+              "reading": "だいさん",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 3405,
+              "displayValue": "3405",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "第三",
+              "reading": "だいさん",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 78695,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "第三",
+              "reading": "だいさん",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 4616,
+              "displayValue": "4616",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "第三",
+              "reading": "だいさん",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 279165,
+              "displayValue": "279165㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "話",
+              "reading": "はなし",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 95,
+              "displayValue": "95",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "話",
+              "reading": "はなし",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 22696,
+              "displayValue": "22696㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "話",
+              "reading": "はなし",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 126,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "話",
+              "reading": "はなし",
+              "dictionary": "CC100",
+              "hasReading": false,
+              "frequency": 126356,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "話",
+              "reading": "はなし",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 103,
+              "displayValue": "103",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "話",
+              "reading": "はなし",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 17535,
+              "displayValue": "17535㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "を",
+              "reading": "を",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 4,
+              "displayValue": "4㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "を",
+              "reading": "を",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 5,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "を",
+              "reading": "を",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 4,
+              "displayValue": "4㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "見る",
+              "reading": null
+            },
+            {
+              "term": "見た",
+              "reading": null
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "見る",
+              "reading": "みる",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 36,
+              "displayValue": "36",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "見る",
+              "reading": "みる",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 110,
+              "displayValue": "110㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "見る",
+              "reading": "みる",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 33,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "見る",
+              "reading": "みる",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 46,
+              "displayValue": "46",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "見る",
+              "reading": "みる",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 895,
+              "displayValue": "895㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      }
+    ],
+    "scripts": [
+      {
+        "sha256": "fb64f047eb0494f136bb92311df43c5318873298fe3efad6bfa82e5d531a93e1",
+        "marker": "optionsGetFull",
+        "result": {
+          "profileIndex": 0,
+          "scanLength": 21,
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ],
+          "dictionaryPriorityByName": {
+            "Jitendex.org [2026-03-05]": 0,
+            "日本語文法辞典(全集)": 1,
+            "JPDBv2㋕": 2,
+            "Jiten": 3,
+            "CC100": 4,
+            "実用日本語表現辞典": 5,
+            "NHK": 6,
+            "SubMiner Character Dictionary": 7
+          },
+          "dictionaryFrequencyModeByName": {
+            "JPDBv2㋕": "rank-based",
+            "Jiten": "rank-based"
+          }
+        }
+      },
+      {
+        "sha256": "0128ae2a23cb40458330fdaa93d3bcb2e64c8cb88187e93ae34ad4aed942e8da",
+        "marker": "parseText",
+        "result": [
+          {
+            "id": "scan",
+            "source": "scanning-parser",
+            "dictionary": null,
+            "index": 0,
+            "content": [
+              [
+                {
+                  "text": "第三",
+                  "reading": "だいさん",
+                  "headwords": [
+                    [
+                      {
+                        "term": "第三",
+                        "reading": "だいさん",
+                        "sources": [
+                          {
+                            "originalText": "第三",
+                            "transformedText": "第三",
+                            "deinflectedText": "第三",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "話",
+                  "reading": "はなし",
+                  "headwords": [
+                    [
+                      {
+                        "term": "話",
+                        "reading": "はなし",
+                        "sources": [
+                          {
+                            "originalText": "話",
+                            "transformedText": "話",
+                            "deinflectedText": "話",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "話",
+                        "reading": "わ",
+                        "sources": [
+                          {
+                            "originalText": "話",
+                            "transformedText": "話",
+                            "deinflectedText": "話",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "を",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "を",
+                        "reading": "を",
+                        "sources": [
+                          {
+                            "originalText": "を",
+                            "transformedText": "を",
+                            "deinflectedText": "を",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "見",
+                  "reading": "み",
+                  "headwords": [
+                    [
+                      {
+                        "term": "見る",
+                        "reading": "みる",
+                        "sources": [
+                          {
+                            "originalText": "見た",
+                            "transformedText": "見た",
+                            "deinflectedText": "見る",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "text": "た",
+                  "reading": ""
+                }
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "f3e28b907d27523ba5d7824aa5e95210fc3807f6319af9a75caaff1992f11aaf",
+        "marker": "termsFind",
+        "result": [
+          {
+            "surface": "第三",
+            "reading": "だいさん",
+            "headword": "第三",
+            "headwordReading": "だいさん",
+            "startPos": 0,
+            "endPos": 2,
+            "isNameMatch": false,
+            "frequencyRank": 3405
+          },
+          {
+            "surface": "話",
+            "reading": "はなし",
+            "headword": "話",
+            "headwordReading": "はなし",
+            "startPos": 2,
+            "endPos": 3,
+            "isNameMatch": false,
+            "frequencyRank": 95
+          },
+          {
+            "surface": "を",
+            "reading": "を",
+            "headword": "を",
+            "headwordReading": "を",
+            "startPos": 3,
+            "endPos": 4,
+            "isNameMatch": false,
+            "frequencyRank": 4
+          },
+          {
+            "surface": "見た",
+            "reading": "みた",
+            "headword": "見る",
+            "headwordReading": "みる",
+            "startPos": 4,
+            "endPos": 6,
+            "isNameMatch": false,
+            "frequencyRank": 36,
+            "wordClasses": [
+              "v1"
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "521c9d6a7068c6df504a0764bb45f46bc98d0b682cadcddd32623dfc29112f83",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "第三",
+            "reading": "だいさん",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 3405,
+            "displayValue": "3405",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "第三",
+            "reading": "だいさん",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 78695,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "第三",
+            "reading": "だいさん",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 4616,
+            "displayValue": "4616",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "第三",
+            "reading": "だいさん",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 279165,
+            "displayValue": "279165㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "話",
+            "reading": "はなし",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 95,
+            "displayValue": "95",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "話",
+            "reading": "はなし",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 22696,
+            "displayValue": "22696㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "話",
+            "reading": "はなし",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 126,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "話",
+            "reading": "はなし",
+            "dictionary": "CC100",
+            "hasReading": false,
+            "frequency": 126356,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "話",
+            "reading": "はなし",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 103,
+            "displayValue": "103",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "話",
+            "reading": "はなし",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 17535,
+            "displayValue": "17535㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "を",
+            "reading": "を",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 4,
+            "displayValue": "4㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "を",
+            "reading": "を",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 5,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "を",
+            "reading": "を",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 4,
+            "displayValue": "4㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      },
+      {
+        "sha256": "51d5618483b16e8410e66cf88f384b7be7025177557e1bc1b91912073eac28b1",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "見る",
+            "reading": "みる",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 36,
+            "displayValue": "36",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "見る",
+            "reading": "みる",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 110,
+            "displayValue": "110㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "見る",
+            "reading": "みる",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 33,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "見る",
+            "reading": "みる",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 46,
+            "displayValue": "46",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "見る",
+            "reading": "みる",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 895,
+            "displayValue": "895㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      }
+    ],
+    "mecab": {
+      "第三話を見た": [
+        {
+          "word": "第",
+          "partOfSpeech": "other",
+          "pos1": "接頭詞",
+          "pos2": "数接続",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "第",
+          "katakanaReading": "ダイ",
+          "pronunciation": "ダイ"
+        },
+        {
+          "word": "三",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "数",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "三",
+          "katakanaReading": "サン",
+          "pronunciation": "サン"
+        },
+        {
+          "word": "話",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "接尾",
+          "pos3": "助数詞",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "話",
+          "katakanaReading": "ワ",
+          "pronunciation": "ワ"
+        },
+        {
+          "word": "を",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "格助詞",
+          "pos3": "一般",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "を",
+          "katakanaReading": "ヲ",
+          "pronunciation": "ヲ"
+        },
+        {
+          "word": "見",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "一段",
+          "inflectionForm": "連用形",
+          "headword": "見る",
+          "katakanaReading": "ミ",
+          "pronunciation": "ミ"
+        },
+        {
+          "word": "た",
+          "partOfSpeech": "bound_auxiliary",
+          "pos1": "助動詞",
+          "pos2": "*",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "特殊・タ",
+          "inflectionForm": "基本形",
+          "headword": "た",
+          "katakanaReading": "タ",
+          "pronunciation": "タ"
+        }
+      ]
+    }
+  },
+  "expected": {
+    "tokens": [
+      {
+        "surface": "第三",
+        "reading": "だいさん",
+        "headword": "第三",
+        "startPos": 0,
+        "endPos": 2,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "だいさん",
+        "pos1": "接頭詞|名詞",
+        "pos2": "数接続|数",
+        "pos3": "*",
+        "frequencyRank": 3405
+      },
+      {
+        "surface": "話",
+        "reading": "はなし",
+        "headword": "話",
+        "startPos": 2,
+        "endPos": 3,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "はなし",
+        "pos1": "名詞",
+        "pos2": "数",
+        "pos3": "*",
+        "frequencyRank": 95
+      },
+      {
+        "surface": "を",
+        "reading": "を",
+        "headword": "を",
+        "startPos": 3,
+        "endPos": 4,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "を",
+        "pos1": "助詞",
+        "pos2": "格助詞",
+        "pos3": "一般"
+      },
+      {
+        "surface": "見た",
+        "reading": "みた",
+        "headword": "見る",
+        "startPos": 4,
+        "endPos": 6,
+        "partOfSpeech": "verb",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "みる",
+        "pos1": "動詞",
+        "pos2": "自立",
+        "pos3": "*",
+        "frequencyRank": 36
+      }
+    ]
+  }
+}

--- a/src/core/services/tokenizer/__fixtures__/golden/suru-te-grammar-helper.json
+++ b/src/core/services/tokenizer/__fixtures__/golden/suru-te-grammar-helper.json
@@ -1,0 +1,14586 @@
+{
+  "name": "suru-te-grammar-helper",
+  "description": "standalone shite grammar helper stays plain while content words keep annotations",
+  "issueRefs": [
+    "#153"
+  ],
+  "recordedAt": "2026-07-11T00:49:36.043Z",
+  "input": {
+    "text": "ちゃんと確認してください"
+  },
+  "config": {},
+  "recording": {
+    "messages": [
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "parseText",
+        "params": {
+          "text": "ちゃんと確認してください",
+          "optionsContext": {
+            "index": 0
+          },
+          "scanLength": 21,
+          "useInternalParser": true,
+          "useMecabParser": false
+        },
+        "response": {
+          "result": [
+            {
+              "id": "scan",
+              "source": "scanning-parser",
+              "dictionary": null,
+              "index": 0,
+              "content": [
+                [
+                  {
+                    "text": "ちゃんと",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "ちゃんと",
+                          "reading": "ちゃんと",
+                          "sources": [
+                            {
+                              "originalText": "ちゃんと",
+                              "transformedText": "ちゃんと",
+                              "deinflectedText": "ちゃんと",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "チャント",
+                          "reading": "チャント",
+                          "sources": [
+                            {
+                              "originalText": "ちゃんと",
+                              "transformedText": "チャント",
+                              "deinflectedText": "チャント",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "チャント",
+                          "reading": "チャント",
+                          "sources": [
+                            {
+                              "originalText": "ちゃんと",
+                              "transformedText": "チャント",
+                              "deinflectedText": "チャント",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "確認",
+                    "reading": "かくにん",
+                    "headwords": [
+                      [
+                        {
+                          "term": "確認",
+                          "reading": "かくにん",
+                          "sources": [
+                            {
+                              "originalText": "確認",
+                              "transformedText": "確認",
+                              "deinflectedText": "確認",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "確認",
+                          "reading": "かくにん",
+                          "sources": [
+                            {
+                              "originalText": "確認",
+                              "transformedText": "確認",
+                              "deinflectedText": "確認",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "して",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "して",
+                          "reading": "して",
+                          "sources": [
+                            {
+                              "originalText": "して",
+                              "transformedText": "して",
+                              "deinflectedText": "して",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "仕手",
+                          "reading": "して",
+                          "sources": [
+                            {
+                              "originalText": "して",
+                              "transformedText": "して",
+                              "deinflectedText": "して",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "する",
+                          "reading": "する",
+                          "sources": [
+                            {
+                              "originalText": "して",
+                              "transformedText": "して",
+                              "deinflectedText": "する",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "為る",
+                          "reading": "する",
+                          "sources": [
+                            {
+                              "originalText": "して",
+                              "transformedText": "して",
+                              "deinflectedText": "する",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "シテ",
+                          "reading": "シテ",
+                          "sources": [
+                            {
+                              "originalText": "して",
+                              "transformedText": "シテ",
+                              "deinflectedText": "シテ",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "ください",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "下さい",
+                          "reading": "ください",
+                          "sources": [
+                            {
+                              "originalText": "ください",
+                              "transformedText": "ください",
+                              "deinflectedText": "ください",
+                              "matchType": "exact",
+                              "matchSource": "reading",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ちゃんと確認してください",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ちゃんと",
+                    "reading": "ちゃんと",
+                    "sources": [
+                      {
+                        "originalText": "ちゃんと",
+                        "transformedText": "ちゃんと",
+                        "deinflectedText": "ちゃんと",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "479㋕",
+                    "displayValueParsed": false,
+                    "frequency": 479,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "186㋕",
+                    "displayValueParsed": false,
+                    "frequency": 186,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 976,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "チャント",
+                    "reading": "チャント",
+                    "sources": [
+                      {
+                        "originalText": "ちゃんと",
+                        "transformedText": "チャント",
+                        "deinflectedText": "チャント",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "84493㋕",
+                    "displayValueParsed": false,
+                    "frequency": 84493,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "100241㋕",
+                    "displayValueParsed": false,
+                    "frequency": 100241,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "127102㋕",
+                    "displayValueParsed": false,
+                    "frequency": 127102,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 45461,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ちゃん",
+                    "reading": "ちゃん",
+                    "sources": [
+                      {
+                        "originalText": "ちゃん",
+                        "transformedText": "ちゃん",
+                        "deinflectedText": "ちゃん",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "453㋕",
+                    "displayValueParsed": false,
+                    "frequency": 453,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11601㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "135㋕",
+                    "displayValueParsed": false,
+                    "frequency": 135,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 437,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "父",
+                    "reading": "ちゃん",
+                    "sources": [
+                      {
+                        "originalText": "ちゃん",
+                        "transformedText": "ちゃん",
+                        "deinflectedText": "ちゃん",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10741㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10741,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "荘",
+                    "reading": "チャン",
+                    "sources": [
+                      {
+                        "originalText": "ちゃん",
+                        "transformedText": "チャン",
+                        "deinflectedText": "チャン",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 154875,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "歴青",
+                    "reading": "チャン",
+                    "sources": [
+                      {
+                        "originalText": "ちゃん",
+                        "transformedText": "チャン",
+                        "deinflectedText": "チャン",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "66494㋕",
+                    "displayValueParsed": false,
+                    "frequency": 66494,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -3,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "瀝青",
+                    "reading": "チャン",
+                    "sources": [
+                      {
+                        "originalText": "ちゃん",
+                        "transformedText": "チャン",
+                        "deinflectedText": "チャン",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "66494㋕",
+                    "displayValueParsed": false,
+                    "frequency": 66494,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ちゃ",
+                    "reading": "ちゃ",
+                    "sources": [
+                      {
+                        "originalText": "ちゃ",
+                        "transformedText": "ちゃ",
+                        "deinflectedText": "ちゃ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21396㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21396,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3173㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3173,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6135,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "茶",
+                    "reading": "ちゃ",
+                    "sources": [
+                      {
+                        "originalText": "ちゃ",
+                        "transformedText": "ちゃ",
+                        "deinflectedText": "ちゃ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4106",
+                    "displayValueParsed": false,
+                    "frequency": 4106,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21396㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21396,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3173㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3173,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4984",
+                    "displayValueParsed": false,
+                    "frequency": 4984,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2066,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 75,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 7,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "チ",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "SubMiner Character Dictionary",
+                    "dictionaryAlias": "SubMiner Character Dictionary"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "17086㋕",
+                    "displayValueParsed": false,
+                    "frequency": 17086,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "地",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1033",
+                    "displayValueParsed": false,
+                    "frequency": 1033,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1738",
+                    "displayValueParsed": false,
+                    "frequency": 1738,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1361,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "血",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "645",
+                    "displayValueParsed": false,
+                    "frequency": 645,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "818",
+                    "displayValueParsed": false,
+                    "frequency": 818,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8574㋕",
+                    "displayValueParsed": false,
+                    "frequency": 8574,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3297,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "乳",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 157534,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 97,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "千",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "値",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9501",
+                    "displayValueParsed": false,
+                    "frequency": 9501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12730",
+                    "displayValueParsed": false,
+                    "frequency": 12730,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2937,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145448,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "家",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 95167,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "徴",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "95286",
+                    "displayValueParsed": false,
+                    "frequency": 95286,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 140209,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "治",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14920",
+                    "displayValueParsed": false,
+                    "frequency": 14920,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25884",
+                    "displayValueParsed": false,
+                    "frequency": 25884,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 60036,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 140170,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "痴",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "113702",
+                    "displayValueParsed": false,
+                    "frequency": 113702,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "49422",
+                    "displayValueParsed": false,
+                    "frequency": 49422,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 123317,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 143983,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "知",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5950",
+                    "displayValueParsed": false,
+                    "frequency": 5950,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10475",
+                    "displayValueParsed": false,
+                    "frequency": 10475,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10594,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "笞",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "路",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "205401",
+                    "displayValueParsed": false,
+                    "frequency": 205401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 116274,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鉤",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 138790,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "日",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 76112,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "智",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15759",
+                    "displayValueParsed": false,
+                    "frequency": 15759,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "27708",
+                    "displayValueParsed": false,
+                    "frequency": 27708,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 25338,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "道",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "49001",
+                    "displayValueParsed": false,
+                    "frequency": 49001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25206",
+                    "displayValueParsed": false,
+                    "frequency": 25206,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 104804,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鈎",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -3,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "茅",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "癡",
+                    "reading": "ち",
+                    "sources": [
+                      {
+                        "originalText": "ち",
+                        "transformedText": "ち",
+                        "deinflectedText": "ち",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "127507",
+                    "displayValueParsed": false,
+                    "frequency": 127507,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "164448",
+                    "displayValueParsed": false,
+                    "frequency": 164448,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 135936,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 4
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ゃんと確認してください",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [],
+            "originalTextLength": 0
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "んと確認してください",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ん",
+                    "reading": "ん",
+                    "sources": [
+                      {
+                        "originalText": "ん",
+                        "transformedText": "ん",
+                        "deinflectedText": "ん",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34001㋕",
+                    "displayValueParsed": false,
+                    "frequency": 34001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ン",
+                    "reading": "ン",
+                    "sources": [
+                      {
+                        "originalText": "ん",
+                        "transformedText": "ン",
+                        "deinflectedText": "ン",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8493㋕",
+                    "displayValueParsed": false,
+                    "frequency": 8493,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1528㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1528,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27611,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "と確認してください",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "と",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 10,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "戸",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3806",
+                    "displayValueParsed": false,
+                    "frequency": 3806,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5558",
+                    "displayValueParsed": false,
+                    "frequency": 5558,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18575,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 116932,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "斗",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "20270",
+                    "displayValueParsed": false,
+                    "frequency": 20270,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23670",
+                    "displayValueParsed": false,
+                    "frequency": 23670,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 33001,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "途",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24217",
+                    "displayValueParsed": false,
+                    "frequency": 24217,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "31921",
+                    "displayValueParsed": false,
+                    "frequency": 31921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 54709,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 146147,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "門",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "93601",
+                    "displayValueParsed": false,
+                    "frequency": 93601,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "十",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "人",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22801",
+                    "displayValueParsed": false,
+                    "frequency": 22801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 74510,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "堵",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75328",
+                    "displayValueParsed": false,
+                    "frequency": 75328,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "106346",
+                    "displayValueParsed": false,
+                    "frequency": 106346,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 111823,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "徒",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10243",
+                    "displayValueParsed": false,
+                    "frequency": 10243,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15811",
+                    "displayValueParsed": false,
+                    "frequency": 15811,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 7442,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "砥",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "85752",
+                    "displayValueParsed": false,
+                    "frequency": 85752,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "106555",
+                    "displayValueParsed": false,
+                    "frequency": 106555,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 72831,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "都",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4376",
+                    "displayValueParsed": false,
+                    "frequency": 4376,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6942",
+                    "displayValueParsed": false,
+                    "frequency": 6942,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6567,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 140456,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "土",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 112427,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "外",
+                    "reading": "と",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "と",
+                        "deinflectedText": "と",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ト",
+                    "reading": "ト",
+                    "sources": [
+                      {
+                        "originalText": "と",
+                        "transformedText": "ト",
+                        "deinflectedText": "ト",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11193㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11193,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 38808,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "確認してください",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "確認",
+                    "reading": "かくにん",
+                    "sources": [
+                      {
+                        "originalText": "確認",
+                        "transformedText": "確認",
+                        "deinflectedText": "確認",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "525",
+                    "displayValueParsed": false,
+                    "frequency": 525,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "121840㋕",
+                    "displayValueParsed": false,
+                    "frequency": 121840,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "539",
+                    "displayValueParsed": false,
+                    "frequency": 539,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "59307㋕",
+                    "displayValueParsed": false,
+                    "frequency": 59307,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "確",
+                    "reading": "かく",
+                    "sources": [
+                      {
+                        "originalText": "確",
+                        "transformedText": "確",
+                        "deinflectedText": "確",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21771",
+                    "displayValueParsed": false,
+                    "frequency": 21771,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "38765",
+                    "displayValueParsed": false,
+                    "frequency": 38765,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "195310㋕",
+                    "displayValueParsed": false,
+                    "frequency": 195310,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 32973,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "確",
+                    "reading": "たしか",
+                    "sources": [
+                      {
+                        "originalText": "確",
+                        "transformedText": "確",
+                        "deinflectedText": "確",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3891㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3891,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "280601",
+                    "displayValueParsed": false,
+                    "frequency": 280601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3829㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3829,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "38349",
+                    "displayValueParsed": false,
+                    "frequency": 38349,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "認してください",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [],
+            "originalTextLength": 0
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "してください",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "して",
+                    "reading": "して",
+                    "sources": [
+                      {
+                        "originalText": "して",
+                        "transformedText": "して",
+                        "deinflectedText": "して",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "293426㋕",
+                    "displayValueParsed": false,
+                    "frequency": 293426,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "95㋕",
+                    "displayValueParsed": false,
+                    "frequency": 95,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26808,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "仕手",
+                    "reading": "して",
+                    "sources": [
+                      {
+                        "originalText": "して",
+                        "transformedText": "して",
+                        "deinflectedText": "して",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "59821",
+                    "displayValueParsed": false,
+                    "frequency": 59821,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "44520㋕",
+                    "displayValueParsed": false,
+                    "frequency": 44520,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "88054",
+                    "displayValueParsed": false,
+                    "frequency": 88054,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 40124,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "する",
+                    "reading": "する",
+                    "sources": [
+                      {
+                        "originalText": "して",
+                        "transformedText": "して",
+                        "deinflectedText": "する",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "vs"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 29501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "60801㋕",
+                    "displayValueParsed": false,
+                    "frequency": 60801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "216501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 216501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 15,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "-て",
+                        "description": "て-form.\nIt has a myriad of meanings. Primarily, it is a conjunctive particle that connects two clauses together.\nUsage: Attach て to the continuative form (連用形) of verbs after euphonic change form, くて to the stem of i-adjectives."
+                      }
+                    ]
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "為る",
+                    "reading": "する",
+                    "sources": [
+                      {
+                        "originalText": "して",
+                        "transformedText": "して",
+                        "deinflectedText": "する",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "vs"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "11㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34586",
+                    "displayValueParsed": false,
+                    "frequency": 34586,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "34194",
+                    "displayValueParsed": false,
+                    "frequency": 34194,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126264,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "シテ",
+                    "reading": "シテ",
+                    "sources": [
+                      {
+                        "originalText": "して",
+                        "transformedText": "シテ",
+                        "deinflectedText": "シテ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "30095㋕",
+                    "displayValueParsed": false,
+                    "frequency": 30095,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "215312㋕",
+                    "displayValueParsed": false,
+                    "frequency": 215312,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21685㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21685,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62046,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "し",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "58㋕",
+                    "displayValueParsed": false,
+                    "frequency": 58,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40㋕",
+                    "displayValueParsed": false,
+                    "frequency": 40,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 107,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "史",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10409",
+                    "displayValueParsed": false,
+                    "frequency": 10409,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14354",
+                    "displayValueParsed": false,
+                    "frequency": 14354,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5055,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 148554,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "四",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2539",
+                    "displayValueParsed": false,
+                    "frequency": 2539,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10427㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10427,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11632,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "市",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2466",
+                    "displayValueParsed": false,
+                    "frequency": 2466,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5353",
+                    "displayValueParsed": false,
+                    "frequency": 5353,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36419㋕",
+                    "displayValueParsed": false,
+                    "frequency": 36419,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1754,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "死",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "909",
+                    "displayValueParsed": false,
+                    "frequency": 909,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1050",
+                    "displayValueParsed": false,
+                    "frequency": 1050,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2640,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "氏",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2076",
+                    "displayValueParsed": false,
+                    "frequency": 2076,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3723",
+                    "displayValueParsed": false,
+                    "frequency": 3723,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "128121㋕",
+                    "displayValueParsed": false,
+                    "frequency": 128121,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 754,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "詩",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6043",
+                    "displayValueParsed": false,
+                    "frequency": 6043,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10033",
+                    "displayValueParsed": false,
+                    "frequency": 10033,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5328,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "誌",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14324",
+                    "displayValueParsed": false,
+                    "frequency": 14324,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13547",
+                    "displayValueParsed": false,
+                    "frequency": 13547,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "137640㋕",
+                    "displayValueParsed": false,
+                    "frequency": 137640,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4850,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "４",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10427㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10427,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "264167",
+                    "displayValueParsed": false,
+                    "frequency": 264167,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 99,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "巳",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 98,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "肆",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "52126",
+                    "displayValueParsed": false,
+                    "frequency": 52126,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10427㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10427,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "68597",
+                    "displayValueParsed": false,
+                    "frequency": 68597,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "仕",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18118",
+                    "displayValueParsed": false,
+                    "frequency": 18118,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "32118",
+                    "displayValueParsed": false,
+                    "frequency": 32118,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "使",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12360",
+                    "displayValueParsed": false,
+                    "frequency": 12360,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21052",
+                    "displayValueParsed": false,
+                    "frequency": 21052,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 17476,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "其",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158683,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "刺",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "35602",
+                    "displayValueParsed": false,
+                    "frequency": 35602,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "51452",
+                    "displayValueParsed": false,
+                    "frequency": 51452,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 60206,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134182,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "司",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "245837",
+                    "displayValueParsed": false,
+                    "frequency": 245837,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30293,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 142553,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "嗣",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "51965",
+                    "displayValueParsed": false,
+                    "frequency": 51965,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65105",
+                    "displayValueParsed": false,
+                    "frequency": 65105,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "士",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3773",
+                    "displayValueParsed": false,
+                    "frequency": 3773,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "9983",
+                    "displayValueParsed": false,
+                    "frequency": 9983,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4136,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 153328,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "姉",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "90301",
+                    "displayValueParsed": false,
+                    "frequency": 90301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "219321",
+                    "displayValueParsed": false,
+                    "frequency": 219321,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "245837㋕",
+                    "displayValueParsed": false,
+                    "frequency": 245837,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126411,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "子",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5502",
+                    "displayValueParsed": false,
+                    "frequency": 5502,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11200",
+                    "displayValueParsed": false,
+                    "frequency": 11200,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8832,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 103435,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "巵",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "師",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3406",
+                    "displayValueParsed": false,
+                    "frequency": 3406,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5245",
+                    "displayValueParsed": false,
+                    "frequency": 5245,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5527,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "支",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "25170",
+                    "displayValueParsed": false,
+                    "frequency": 25170,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "28969",
+                    "displayValueParsed": false,
+                    "frequency": 28969,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 42808,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "枝",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "26201",
+                    "displayValueParsed": false,
+                    "frequency": 26201,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "191088",
+                    "displayValueParsed": false,
+                    "frequency": 191088,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 33497,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 136579,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "歯",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "122301",
+                    "displayValueParsed": false,
+                    "frequency": 122301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "264167",
+                    "displayValueParsed": false,
+                    "frequency": 264167,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 138591,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "私",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "26101",
+                    "displayValueParsed": false,
+                    "frequency": 26101,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 42850,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 150240,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "秭",
+                    "reading": "し",
+                    "sources": [
+                      {
+                        "originalText": "し",
+                        "transformedText": "し",
+                        "deinflectedText": "し",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "235141",
+                    "displayValueParsed": false,
+                    "frequency": 235141,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "274744",
+                    "displayValueParsed": false,
+                    "frequency": 274744,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "てください",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "手管",
+                    "reading": "てくだ",
+                    "sources": [
+                      {
+                        "originalText": "てくだ",
+                        "transformedText": "てくだ",
+                        "deinflectedText": "てくだ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34228",
+                    "displayValueParsed": false,
+                    "frequency": 34228,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "166258㋕",
+                    "displayValueParsed": false,
+                    "frequency": 166258,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36202",
+                    "displayValueParsed": false,
+                    "frequency": 36202,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "227467㋕",
+                    "displayValueParsed": false,
+                    "frequency": 227467,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 73648,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "てく",
+                    "reading": "てく",
+                    "sources": [
+                      {
+                        "originalText": "てく",
+                        "transformedText": "てく",
+                        "deinflectedText": "てく",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v5"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5937㋕",
+                    "displayValueParsed": false,
+                    "frequency": 5937,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4276,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "テク",
+                    "reading": "テク",
+                    "sources": [
+                      {
+                        "originalText": "てく",
+                        "transformedText": "テク",
+                        "deinflectedText": "テク",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29638㋕",
+                    "displayValueParsed": false,
+                    "frequency": 29638,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15049㋕",
+                    "displayValueParsed": false,
+                    "frequency": 15049,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18832,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 199,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "て",
+                    "reading": "て",
+                    "sources": [
+                      {
+                        "originalText": "て",
+                        "transformedText": "て",
+                        "deinflectedText": "て",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      },
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "159㋕",
+                    "displayValueParsed": false,
+                    "frequency": 159,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "450㋕",
+                    "displayValueParsed": false,
+                    "frequency": 450,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "手",
+                    "reading": "て",
+                    "sources": [
+                      {
+                        "originalText": "て",
+                        "transformedText": "て",
+                        "deinflectedText": "て",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "114",
+                    "displayValueParsed": false,
+                    "frequency": 114,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "154",
+                    "displayValueParsed": false,
+                    "frequency": 154,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12492㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12492,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 200,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 122414,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": [
+                      {
+                        "name": "continuative",
+                        "description": "Used to indicate actions that are (being) carried out.\nRefers to 連用形, the part of the verb after conjugating with -ます and dropping ます."
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "てる",
+                    "reading": "てる",
+                    "sources": [
+                      {
+                        "originalText": "て",
+                        "transformedText": "て",
+                        "deinflectedText": "てる",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "v1"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1580㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1580,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "57901㋕",
+                    "displayValueParsed": false,
+                    "frequency": 57901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1094㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1094,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 54,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ください",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "下さい",
+                    "reading": "ください",
+                    "sources": [
+                      {
+                        "originalText": "ください",
+                        "transformedText": "ください",
+                        "deinflectedText": "ください",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "460㋕",
+                    "displayValueParsed": false,
+                    "frequency": 460,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "63193",
+                    "displayValueParsed": false,
+                    "frequency": 63193,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "366㋕",
+                    "displayValueParsed": false,
+                    "frequency": 366,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3291",
+                    "displayValueParsed": false,
+                    "frequency": 3291,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "管",
+                    "reading": "くだ",
+                    "sources": [
+                      {
+                        "originalText": "くだ",
+                        "transformedText": "くだ",
+                        "deinflectedText": "くだ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 17046,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 128776,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 1,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "く",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16536,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "区",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5333",
+                    "displayValueParsed": false,
+                    "frequency": 5333,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8408",
+                    "displayValueParsed": false,
+                    "frequency": 8408,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4365,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "句",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15976",
+                    "displayValueParsed": false,
+                    "frequency": 15976,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "26161",
+                    "displayValueParsed": false,
+                    "frequency": 26161,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 12180,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 197,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "九",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8115,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 96,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "９",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 95,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "玖",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3448㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3448,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "口",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "24209",
+                    "displayValueParsed": false,
+                    "frequency": 24209,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "257996㋕",
+                    "displayValueParsed": false,
+                    "frequency": 257996,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 118438,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "垢",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "126601",
+                    "displayValueParsed": false,
+                    "frequency": 126601,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "矩",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "208293",
+                    "displayValueParsed": false,
+                    "frequency": 208293,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 124056,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "苦",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7738",
+                    "displayValueParsed": false,
+                    "frequency": 7738,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "7172",
+                    "displayValueParsed": false,
+                    "frequency": 7172,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8025,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "躯",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "231447",
+                    "displayValueParsed": false,
+                    "frequency": 231447,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 68383,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "軀",
+                    "reading": "く",
+                    "sources": [
+                      {
+                        "originalText": "く",
+                        "transformedText": "く",
+                        "deinflectedText": "く",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 139105,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 4
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ださい",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ださい",
+                    "reading": "ださい",
+                    "sources": [
+                      {
+                        "originalText": "ださい",
+                        "transformedText": "ださい",
+                        "deinflectedText": "ださい",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": [
+                      "adj-i"
+                    ]
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "32081㋕",
+                    "displayValueParsed": false,
+                    "frequency": 32081,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21177㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21177,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 15840,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "だ",
+                    "reading": "だ",
+                    "sources": [
+                      {
+                        "originalText": "だ",
+                        "transformedText": "だ",
+                        "deinflectedText": "だ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10㋕",
+                    "displayValueParsed": false,
+                    "frequency": 10,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "9㋕",
+                    "displayValueParsed": false,
+                    "frequency": 9,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "兌",
+                    "reading": "だ",
+                    "sources": [
+                      {
+                        "originalText": "だ",
+                        "transformedText": "だ",
+                        "deinflectedText": "だ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "90746",
+                    "displayValueParsed": false,
+                    "frequency": 90746,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "111631",
+                    "displayValueParsed": false,
+                    "frequency": 111631,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143㋕",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "打",
+                    "reading": "だ",
+                    "sources": [
+                      {
+                        "originalText": "だ",
+                        "transformedText": "だ",
+                        "deinflectedText": "だ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7827",
+                    "displayValueParsed": false,
+                    "frequency": 7827,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13246",
+                    "displayValueParsed": false,
+                    "frequency": 13246,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23881㋕",
+                    "displayValueParsed": false,
+                    "frequency": 23881,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 16384,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "朶",
+                    "reading": "だ",
+                    "sources": [
+                      {
+                        "originalText": "だ",
+                        "transformedText": "だ",
+                        "deinflectedText": "だ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "87860",
+                    "displayValueParsed": false,
+                    "frequency": 87860,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "121080",
+                    "displayValueParsed": false,
+                    "frequency": 121080,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "駄",
+                    "reading": "だ",
+                    "sources": [
+                      {
+                        "originalText": "だ",
+                        "transformedText": "だ",
+                        "deinflectedText": "だ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "25322",
+                    "displayValueParsed": false,
+                    "frequency": 25322,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23793",
+                    "displayValueParsed": false,
+                    "frequency": 23793,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 43954,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 3
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "さい",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "さい",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7685㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7685,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22971㋕",
+                    "displayValueParsed": false,
+                    "frequency": 22971,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29727㋕",
+                    "displayValueParsed": false,
+                    "frequency": 29727,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "113902㋕",
+                    "displayValueParsed": false,
+                    "frequency": 113902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "166201㋕",
+                    "displayValueParsed": false,
+                    "frequency": 166201,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "48108㋕",
+                    "displayValueParsed": false,
+                    "frequency": 48108,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 21630,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "差異",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15579",
+                    "displayValueParsed": false,
+                    "frequency": 15579,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19548",
+                    "displayValueParsed": false,
+                    "frequency": 19548,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8927,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 72297,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "債",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "79536",
+                    "displayValueParsed": false,
+                    "frequency": 79536,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "166201㋕",
+                    "displayValueParsed": false,
+                    "frequency": 166201,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "68237㋕",
+                    "displayValueParsed": false,
+                    "frequency": 68237,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "73016",
+                    "displayValueParsed": false,
+                    "frequency": 73016,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24636,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "再",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5060",
+                    "displayValueParsed": false,
+                    "frequency": 5060,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4347",
+                    "displayValueParsed": false,
+                    "frequency": 4347,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "27507㋕",
+                    "displayValueParsed": false,
+                    "frequency": 27507,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1699,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "才",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9606",
+                    "displayValueParsed": false,
+                    "frequency": 9606,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "22971㋕",
+                    "displayValueParsed": false,
+                    "frequency": 22971,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "20201",
+                    "displayValueParsed": false,
+                    "frequency": 20201,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "18826",
+                    "displayValueParsed": false,
+                    "frequency": 18826,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "48108㋕",
+                    "displayValueParsed": false,
+                    "frequency": 48108,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 7717,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "歳",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "419",
+                    "displayValueParsed": false,
+                    "frequency": 419,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "764",
+                    "displayValueParsed": false,
+                    "frequency": 764,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "48108㋕",
+                    "displayValueParsed": false,
+                    "frequency": 48108,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 247,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "際",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1237",
+                    "displayValueParsed": false,
+                    "frequency": 1237,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "7685㋕",
+                    "displayValueParsed": false,
+                    "frequency": 7685,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1389",
+                    "displayValueParsed": false,
+                    "frequency": 1389,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4454㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4454,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 191,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "妻",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "121401",
+                    "displayValueParsed": false,
+                    "frequency": 121401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 151182,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "最",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6252",
+                    "displayValueParsed": false,
+                    "frequency": 6252,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29727㋕",
+                    "displayValueParsed": false,
+                    "frequency": 29727,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "5360",
+                    "displayValueParsed": false,
+                    "frequency": 5360,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "56399㋕",
+                    "displayValueParsed": false,
+                    "frequency": 56399,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2953,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "犀",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "49625",
+                    "displayValueParsed": false,
+                    "frequency": 49625,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "62852",
+                    "displayValueParsed": false,
+                    "frequency": 62852,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 31157,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "細",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "32296",
+                    "displayValueParsed": false,
+                    "frequency": 32296,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "27177",
+                    "displayValueParsed": false,
+                    "frequency": 27177,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 43635,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "菜",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "51403",
+                    "displayValueParsed": false,
+                    "frequency": 51403,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "44874",
+                    "displayValueParsed": false,
+                    "frequency": 44874,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143㋕",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 36031,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 143251,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "裁",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "44717",
+                    "displayValueParsed": false,
+                    "frequency": 44717,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "35484",
+                    "displayValueParsed": false,
+                    "frequency": 35484,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 49283,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "賽",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34922",
+                    "displayValueParsed": false,
+                    "frequency": 34922,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "38259",
+                    "displayValueParsed": false,
+                    "frequency": 38259,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 54833,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "載",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45837",
+                    "displayValueParsed": false,
+                    "frequency": 45837,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40698",
+                    "displayValueParsed": false,
+                    "frequency": 40698,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "采",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "40670",
+                    "displayValueParsed": false,
+                    "frequency": 40670,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "70924",
+                    "displayValueParsed": false,
+                    "frequency": 70924,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 92778,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "釵",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "140867",
+                    "displayValueParsed": false,
+                    "frequency": 140867,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "217794",
+                    "displayValueParsed": false,
+                    "frequency": 217794,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "差違",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "56430",
+                    "displayValueParsed": false,
+                    "frequency": 56430,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "73190",
+                    "displayValueParsed": false,
+                    "frequency": 73190,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 86764,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "骰子",
+                    "reading": "さい",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "さい",
+                        "deinflectedText": "さい",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "サイ",
+                    "reading": "サイ",
+                    "sources": [
+                      {
+                        "originalText": "さい",
+                        "transformedText": "サイ",
+                        "deinflectedText": "サイ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47899㋕",
+                    "displayValueParsed": false,
+                    "frequency": 47899,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "166443㋕",
+                    "displayValueParsed": false,
+                    "frequency": 166443,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "174961㋕",
+                    "displayValueParsed": false,
+                    "frequency": 174961,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "158493㋕",
+                    "displayValueParsed": false,
+                    "frequency": 158493,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23934,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "さ",
+                    "reading": "さ",
+                    "sources": [
+                      {
+                        "originalText": "さ",
+                        "transformedText": "さ",
+                        "deinflectedText": "さ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      },
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "87㋕",
+                    "displayValueParsed": false,
+                    "frequency": 87,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "118㋕",
+                    "displayValueParsed": false,
+                    "frequency": 118,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 113,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "差",
+                    "reading": "さ",
+                    "sources": [
+                      {
+                        "originalText": "さ",
+                        "transformedText": "さ",
+                        "deinflectedText": "さ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1219",
+                    "displayValueParsed": false,
+                    "frequency": 1219,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1865",
+                    "displayValueParsed": false,
+                    "frequency": 1865,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1213,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "左",
+                    "reading": "さ",
+                    "sources": [
+                      {
+                        "originalText": "さ",
+                        "transformedText": "さ",
+                        "deinflectedText": "さ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "60803",
+                    "displayValueParsed": false,
+                    "frequency": 60803,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "69095",
+                    "displayValueParsed": false,
+                    "frequency": 69095,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 29174,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "然",
+                    "reading": "さ",
+                    "sources": [
+                      {
+                        "originalText": "さ",
+                        "transformedText": "さ",
+                        "deinflectedText": "さ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47092",
+                    "displayValueParsed": false,
+                    "frequency": 47092,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "68040㋕",
+                    "displayValueParsed": false,
+                    "frequency": 68040,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 42232,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 108054,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "狭",
+                    "reading": "さ",
+                    "sources": [
+                      {
+                        "originalText": "さ",
+                        "transformedText": "さ",
+                        "deinflectedText": "さ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "104602",
+                    "displayValueParsed": false,
+                    "frequency": 104602,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13442㋕",
+                    "displayValueParsed": false,
+                    "frequency": 13442,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25493",
+                    "displayValueParsed": false,
+                    "frequency": 25493,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "小",
+                    "reading": "さ",
+                    "sources": [
+                      {
+                        "originalText": "さ",
+                        "transformedText": "さ",
+                        "deinflectedText": "さ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "190701",
+                    "displayValueParsed": false,
+                    "frequency": 190701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13442㋕",
+                    "displayValueParsed": false,
+                    "frequency": 13442,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "37045",
+                    "displayValueParsed": false,
+                    "frequency": 37045,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 141511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "沙",
+                    "reading": "さ",
+                    "sources": [
+                      {
+                        "originalText": "さ",
+                        "transformedText": "さ",
+                        "deinflectedText": "さ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 87881,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "矢",
+                    "reading": "さ",
+                    "sources": [
+                      {
+                        "originalText": "さ",
+                        "transformedText": "さ",
+                        "deinflectedText": "さ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "箭",
+                    "reading": "さ",
+                    "sources": [
+                      {
+                        "originalText": "さ",
+                        "transformedText": "さ",
+                        "deinflectedText": "さ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "い",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "い",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  },
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2803,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "亥",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47280",
+                    "displayValueParsed": false,
+                    "frequency": 47280,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "56084",
+                    "displayValueParsed": false,
+                    "frequency": 56084,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46249,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伊",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14364",
+                    "displayValueParsed": false,
+                    "frequency": 14364,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30166",
+                    "displayValueParsed": false,
+                    "frequency": 30166,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27119,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "位",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4902",
+                    "displayValueParsed": false,
+                    "frequency": 4902,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4817",
+                    "displayValueParsed": false,
+                    "frequency": 4817,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 967,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 134715,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "医",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15864",
+                    "displayValueParsed": false,
+                    "frequency": 15864,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19720",
+                    "displayValueParsed": false,
+                    "frequency": 19720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5024,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胃",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4320",
+                    "displayValueParsed": false,
+                    "frequency": 4320,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4265",
+                    "displayValueParsed": false,
+                    "frequency": 4265,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "16129㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16129,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4335,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 94,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158511,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 93,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 92,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "伍",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "井",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6111",
+                    "displayValueParsed": false,
+                    "frequency": 6111,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "19958",
+                    "displayValueParsed": false,
+                    "frequency": 19958,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18798,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "偉",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "42742",
+                    "displayValueParsed": false,
+                    "frequency": 42742,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "40683",
+                    "displayValueParsed": false,
+                    "frequency": 40683,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "65831㋕",
+                    "displayValueParsed": false,
+                    "frequency": 65831,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62518,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夷",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "75303",
+                    "displayValueParsed": false,
+                    "frequency": 75303,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 85253,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "委",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "42381",
+                    "displayValueParsed": false,
+                    "frequency": 42381,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23040,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "威",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "27002",
+                    "displayValueParsed": false,
+                    "frequency": 27002,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "36921",
+                    "displayValueParsed": false,
+                    "frequency": 36921,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30452,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 126695,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "居",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "45301",
+                    "displayValueParsed": false,
+                    "frequency": 45301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "236493",
+                    "displayValueParsed": false,
+                    "frequency": 236493,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "彙",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "105649",
+                    "displayValueParsed": false,
+                    "frequency": 105649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "160667",
+                    "displayValueParsed": false,
+                    "frequency": 160667,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "意",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4338",
+                    "displayValueParsed": false,
+                    "frequency": 4338,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4069",
+                    "displayValueParsed": false,
+                    "frequency": 4069,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5912,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "易",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 138689,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "汝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "猪",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "118901",
+                    "displayValueParsed": false,
+                    "frequency": 118901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "異",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "14852",
+                    "displayValueParsed": false,
+                    "frequency": 14852,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15812",
+                    "displayValueParsed": false,
+                    "frequency": 15812,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4892,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胆",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145167,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "藺",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "94214",
+                    "displayValueParsed": false,
+                    "frequency": 94214,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "138991",
+                    "displayValueParsed": false,
+                    "frequency": 138991,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 99348,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "衣",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24121,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132574,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豬",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "200568",
+                    "displayValueParsed": false,
+                    "frequency": 200568,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "196521",
+                    "displayValueParsed": false,
+                    "frequency": 196521,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -2,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "豕",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -6,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "緯",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 96278,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "寝",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -103,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "堰",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -106,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "５０",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -107,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五十",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -108,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "五〇",
+                    "reading": "い",
+                    "sources": [
+                      {
+                        "originalText": "い",
+                        "transformedText": "い",
+                        "deinflectedText": "い",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 121488,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "ちゃんと",
+              "reading": "ちゃんと"
+            },
+            {
+              "term": "確認",
+              "reading": "かくにん"
+            },
+            {
+              "term": "して",
+              "reading": "して"
+            },
+            {
+              "term": "下さい",
+              "reading": "ください"
+            },
+            {
+              "term": "ください",
+              "reading": "ください"
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "ちゃんと",
+              "reading": "ちゃんと",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 479,
+              "displayValue": "479㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "ちゃんと",
+              "reading": "ちゃんと",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 976,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "ちゃんと",
+              "reading": "ちゃんと",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 186,
+              "displayValue": "186㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "確認",
+              "reading": "かくにん",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 525,
+              "displayValue": "525",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "確認",
+              "reading": "かくにん",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 121840,
+              "displayValue": "121840㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "確認",
+              "reading": "かくにん",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 150,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "確認",
+              "reading": "かくにん",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 539,
+              "displayValue": "539",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "確認",
+              "reading": "かくにん",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 59307,
+              "displayValue": "59307㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "して",
+              "reading": "して",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 293426,
+              "displayValue": "293426㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "して",
+              "reading": "して",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 26808,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "して",
+              "reading": "して",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 95,
+              "displayValue": "95㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "下さい",
+              "reading": "ください",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 460,
+              "displayValue": "460㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "下さい",
+              "reading": "ください",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": true,
+              "frequency": 63193,
+              "displayValue": "63193",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "下さい",
+              "reading": "ください",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 366,
+              "displayValue": "366㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "下さい",
+              "reading": "ください",
+              "dictionary": "Jiten",
+              "hasReading": true,
+              "frequency": 3291,
+              "displayValue": "3291",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "ください",
+              "reading": "ください",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 460,
+              "displayValue": "460㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "ください",
+              "reading": "ください",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 366,
+              "displayValue": "366㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      }
+    ],
+    "scripts": [
+      {
+        "sha256": "fb64f047eb0494f136bb92311df43c5318873298fe3efad6bfa82e5d531a93e1",
+        "marker": "optionsGetFull",
+        "result": {
+          "profileIndex": 0,
+          "scanLength": 21,
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ],
+          "dictionaryPriorityByName": {
+            "Jitendex.org [2026-03-05]": 0,
+            "日本語文法辞典(全集)": 1,
+            "JPDBv2㋕": 2,
+            "Jiten": 3,
+            "CC100": 4,
+            "実用日本語表現辞典": 5,
+            "NHK": 6,
+            "SubMiner Character Dictionary": 7
+          },
+          "dictionaryFrequencyModeByName": {
+            "JPDBv2㋕": "rank-based",
+            "Jiten": "rank-based"
+          }
+        }
+      },
+      {
+        "sha256": "dddac3ac77b7976591c80ff77e0a1895dc97c1020fc2f809714831be94c55687",
+        "marker": "parseText",
+        "result": [
+          {
+            "id": "scan",
+            "source": "scanning-parser",
+            "dictionary": null,
+            "index": 0,
+            "content": [
+              [
+                {
+                  "text": "ちゃんと",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "ちゃんと",
+                        "reading": "ちゃんと",
+                        "sources": [
+                          {
+                            "originalText": "ちゃんと",
+                            "transformedText": "ちゃんと",
+                            "deinflectedText": "ちゃんと",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "チャント",
+                        "reading": "チャント",
+                        "sources": [
+                          {
+                            "originalText": "ちゃんと",
+                            "transformedText": "チャント",
+                            "deinflectedText": "チャント",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "チャント",
+                        "reading": "チャント",
+                        "sources": [
+                          {
+                            "originalText": "ちゃんと",
+                            "transformedText": "チャント",
+                            "deinflectedText": "チャント",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "確認",
+                  "reading": "かくにん",
+                  "headwords": [
+                    [
+                      {
+                        "term": "確認",
+                        "reading": "かくにん",
+                        "sources": [
+                          {
+                            "originalText": "確認",
+                            "transformedText": "確認",
+                            "deinflectedText": "確認",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "確認",
+                        "reading": "かくにん",
+                        "sources": [
+                          {
+                            "originalText": "確認",
+                            "transformedText": "確認",
+                            "deinflectedText": "確認",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "して",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "して",
+                        "reading": "して",
+                        "sources": [
+                          {
+                            "originalText": "して",
+                            "transformedText": "して",
+                            "deinflectedText": "して",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "仕手",
+                        "reading": "して",
+                        "sources": [
+                          {
+                            "originalText": "して",
+                            "transformedText": "して",
+                            "deinflectedText": "して",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "する",
+                        "reading": "する",
+                        "sources": [
+                          {
+                            "originalText": "して",
+                            "transformedText": "して",
+                            "deinflectedText": "する",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "為る",
+                        "reading": "する",
+                        "sources": [
+                          {
+                            "originalText": "して",
+                            "transformedText": "して",
+                            "deinflectedText": "する",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "シテ",
+                        "reading": "シテ",
+                        "sources": [
+                          {
+                            "originalText": "して",
+                            "transformedText": "シテ",
+                            "deinflectedText": "シテ",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "ください",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "下さい",
+                        "reading": "ください",
+                        "sources": [
+                          {
+                            "originalText": "ください",
+                            "transformedText": "ください",
+                            "deinflectedText": "ください",
+                            "matchType": "exact",
+                            "matchSource": "reading",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "a399ae67c3c5b31e2a94d83b91a948e172826b22804766b962f4a3306fc8793e",
+        "marker": "termsFind",
+        "result": [
+          {
+            "surface": "ちゃんと",
+            "reading": "ちゃんと",
+            "headword": "ちゃんと",
+            "headwordReading": "ちゃんと",
+            "startPos": 0,
+            "endPos": 4,
+            "isNameMatch": false,
+            "frequencyRank": 479
+          },
+          {
+            "surface": "確認",
+            "reading": "かくにん",
+            "headword": "確認",
+            "headwordReading": "かくにん",
+            "startPos": 4,
+            "endPos": 6,
+            "isNameMatch": false,
+            "frequencyRank": 525
+          },
+          {
+            "surface": "して",
+            "reading": "して",
+            "headword": "して",
+            "headwordReading": "して",
+            "startPos": 6,
+            "endPos": 8,
+            "isNameMatch": false,
+            "frequencyRank": 293426
+          },
+          {
+            "surface": "ください",
+            "reading": "ください",
+            "headword": "下さい",
+            "headwordReading": "ください",
+            "startPos": 8,
+            "endPos": 12,
+            "isNameMatch": false,
+            "frequencyRank": 460
+          }
+        ]
+      },
+      {
+        "sha256": "d2882b2fd4be98b4eff043b94815d105777b84355a08a9f35ad31c1e2f3a03d0",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "ちゃんと",
+            "reading": "ちゃんと",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 479,
+            "displayValue": "479㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "ちゃんと",
+            "reading": "ちゃんと",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 976,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "ちゃんと",
+            "reading": "ちゃんと",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 186,
+            "displayValue": "186㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "確認",
+            "reading": "かくにん",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 525,
+            "displayValue": "525",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "確認",
+            "reading": "かくにん",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 121840,
+            "displayValue": "121840㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "確認",
+            "reading": "かくにん",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 150,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "確認",
+            "reading": "かくにん",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 539,
+            "displayValue": "539",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "確認",
+            "reading": "かくにん",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 59307,
+            "displayValue": "59307㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "して",
+            "reading": "して",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 293426,
+            "displayValue": "293426㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "して",
+            "reading": "して",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 26808,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "して",
+            "reading": "して",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 95,
+            "displayValue": "95㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "下さい",
+            "reading": "ください",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 460,
+            "displayValue": "460㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "下さい",
+            "reading": "ください",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": true,
+            "frequency": 63193,
+            "displayValue": "63193",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "下さい",
+            "reading": "ください",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 366,
+            "displayValue": "366㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "下さい",
+            "reading": "ください",
+            "dictionary": "Jiten",
+            "hasReading": true,
+            "frequency": 3291,
+            "displayValue": "3291",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "ください",
+            "reading": "ください",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 460,
+            "displayValue": "460㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "ください",
+            "reading": "ください",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 366,
+            "displayValue": "366㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      }
+    ],
+    "mecab": {
+      "ちゃんと確認してください": [
+        {
+          "word": "ちゃんと",
+          "partOfSpeech": "other",
+          "pos1": "副詞",
+          "pos2": "一般",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "ちゃんと",
+          "katakanaReading": "チャント",
+          "pronunciation": "チャント"
+        },
+        {
+          "word": "確認",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "サ変接続",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "確認",
+          "katakanaReading": "カクニン",
+          "pronunciation": "カクニン"
+        },
+        {
+          "word": "し",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "サ変・スル",
+          "inflectionForm": "連用形",
+          "headword": "する",
+          "katakanaReading": "シ",
+          "pronunciation": "シ"
+        },
+        {
+          "word": "て",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "接続助詞",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "て",
+          "katakanaReading": "テ",
+          "pronunciation": "テ"
+        },
+        {
+          "word": "ください",
+          "partOfSpeech": "verb",
+          "pos1": "動詞",
+          "pos2": "非自立",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "五段・ラ行特殊",
+          "inflectionForm": "命令ｉ",
+          "headword": "くださる",
+          "katakanaReading": "クダサイ",
+          "pronunciation": "クダサイ"
+        }
+      ]
+    }
+  },
+  "expected": {
+    "tokens": [
+      {
+        "surface": "ちゃんと",
+        "reading": "ちゃんと",
+        "headword": "ちゃんと",
+        "startPos": 0,
+        "endPos": 4,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "ちゃんと",
+        "pos1": "副詞",
+        "pos2": "一般",
+        "pos3": "*",
+        "frequencyRank": 479
+      },
+      {
+        "surface": "確認",
+        "reading": "かくにん",
+        "headword": "確認",
+        "startPos": 4,
+        "endPos": 6,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "かくにん",
+        "pos1": "名詞",
+        "pos2": "サ変接続",
+        "pos3": "*",
+        "frequencyRank": 525
+      },
+      {
+        "surface": "して",
+        "reading": "して",
+        "headword": "して",
+        "startPos": 6,
+        "endPos": 8,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "して",
+        "pos1": "動詞",
+        "pos2": "自立",
+        "pos3": "*",
+        "frequencyRank": 293426
+      },
+      {
+        "surface": "ください",
+        "reading": "ください",
+        "headword": "下さい",
+        "startPos": 8,
+        "endPos": 12,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "ください",
+        "pos1": "動詞",
+        "pos2": "自立",
+        "pos3": "*",
+        "frequencyRank": 460
+      }
+    ]
+  }
+}

--- a/src/core/services/tokenizer/__fixtures__/golden/unparsed-run-elongation.json
+++ b/src/core/services/tokenizer/__fixtures__/golden/unparsed-run-elongation.json
@@ -1,0 +1,8356 @@
+{
+  "name": "unparsed-run-elongation",
+  "description": "kana elongation run Yomitan cannot parse stays hoverable but unannotated",
+  "issueRefs": [
+    "#153"
+  ],
+  "recordedAt": "2026-07-11T00:50:05.571Z",
+  "input": {
+    "text": "ぅ～ん…どうかな"
+  },
+  "config": {},
+  "recording": {
+    "messages": [
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "optionsGetFull",
+        "params": null,
+        "response": {
+          "result": {
+            "profileCurrent": 0,
+            "profiles": [
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": true
+                    },
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": true
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": true
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              },
+              {
+                "options": {
+                  "scanning": {
+                    "length": 21
+                  },
+                  "dictionaries": [
+                    {
+                      "name": "JPDBv2㋕",
+                      "enabled": true
+                    },
+                    {
+                      "name": "CC100",
+                      "enabled": true
+                    },
+                    {
+                      "name": "Jiten",
+                      "enabled": false
+                    },
+                    {
+                      "name": "NHK",
+                      "enabled": false
+                    },
+                    {
+                      "name": "日本語文法辞典(全集)",
+                      "enabled": false
+                    },
+                    {
+                      "name": "使い方の分かる 類語例解辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "小学館例解学習国語 第十二版",
+                      "enabled": false
+                    },
+                    {
+                      "name": "実用日本語表現辞典",
+                      "enabled": false
+                    },
+                    {
+                      "name": "Jitendex.org [2026-03-05]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "JMnedict [2026-03-21]",
+                      "enabled": false
+                    },
+                    {
+                      "name": "SubMiner Character Dictionary",
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "action": "getDictionaryInfo",
+        "params": null,
+        "response": {
+          "result": [
+            {
+              "title": "日本語文法辞典(全集)"
+            },
+            {
+              "title": "使い方の分かる 類語例解辞典"
+            },
+            {
+              "title": "小学館例解学習国語 第十二版"
+            },
+            {
+              "title": "実用日本語表現辞典"
+            },
+            {
+              "title": "JPDBv2㋕",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "CC100"
+            },
+            {
+              "title": "NHK"
+            },
+            {
+              "title": "Jitendex.org [2026-03-05]"
+            },
+            {
+              "title": "JMnedict [2026-03-21]"
+            },
+            {
+              "title": "Jiten",
+              "frequencyMode": "rank-based"
+            },
+            {
+              "title": "SubMiner Character Dictionary"
+            }
+          ]
+        }
+      },
+      {
+        "action": "parseText",
+        "params": {
+          "text": "ぅ～ん…どうかな",
+          "optionsContext": {
+            "index": 0
+          },
+          "scanLength": 21,
+          "useInternalParser": true,
+          "useMecabParser": false
+        },
+        "response": {
+          "result": [
+            {
+              "id": "scan",
+              "source": "scanning-parser",
+              "dictionary": null,
+              "index": 0,
+              "content": [
+                [
+                  {
+                    "text": "ぅ～",
+                    "reading": ""
+                  }
+                ],
+                [
+                  {
+                    "text": "ん",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "ん",
+                          "reading": "ん",
+                          "sources": [
+                            {
+                              "originalText": "ん",
+                              "transformedText": "ん",
+                              "deinflectedText": "ん",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "ん",
+                          "reading": "ん",
+                          "sources": [
+                            {
+                              "originalText": "ん",
+                              "transformedText": "ん",
+                              "deinflectedText": "ん",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "ん",
+                          "reading": "ん",
+                          "sources": [
+                            {
+                              "originalText": "ん",
+                              "transformedText": "ん",
+                              "deinflectedText": "ん",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "ん",
+                          "reading": "ん",
+                          "sources": [
+                            {
+                              "originalText": "ん",
+                              "transformedText": "ん",
+                              "deinflectedText": "ん",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ],
+                      [
+                        {
+                          "term": "ン",
+                          "reading": "ン",
+                          "sources": [
+                            {
+                              "originalText": "ん",
+                              "transformedText": "ン",
+                              "deinflectedText": "ン",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ],
+                [
+                  {
+                    "text": "…",
+                    "reading": ""
+                  }
+                ],
+                [
+                  {
+                    "text": "どうかな",
+                    "reading": "",
+                    "headwords": [
+                      [
+                        {
+                          "term": "どうかな",
+                          "reading": "どうかな",
+                          "sources": [
+                            {
+                              "originalText": "どうかな",
+                              "transformedText": "どうかな",
+                              "deinflectedText": "どうかな",
+                              "matchType": "exact",
+                              "matchSource": "term",
+                              "isPrimary": true
+                            }
+                          ],
+                          "frequencies": []
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ぅ～ん…どうかな",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [],
+            "originalTextLength": 0
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "ん…どうかな",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ん",
+                    "reading": "ん",
+                    "sources": [
+                      {
+                        "originalText": "ん",
+                        "transformedText": "ん",
+                        "deinflectedText": "ん",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "54㋕",
+                    "displayValueParsed": false,
+                    "frequency": 54,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34001㋕",
+                    "displayValueParsed": false,
+                    "frequency": 34001,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21㋕",
+                    "displayValueParsed": false,
+                    "frequency": 21,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ン",
+                    "reading": "ン",
+                    "sources": [
+                      {
+                        "originalText": "ん",
+                        "transformedText": "ン",
+                        "deinflectedText": "ン",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8493㋕",
+                    "displayValueParsed": false,
+                    "frequency": 8493,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1528㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1528,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 27611,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "どうかな",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 4,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "どうかな",
+                    "reading": "どうかな",
+                    "sources": [
+                      {
+                        "originalText": "どうかな",
+                        "transformedText": "どうかな",
+                        "deinflectedText": "どうかな",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "3439㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3439,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1610㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1610,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "どうか",
+                    "reading": "どうか",
+                    "sources": [
+                      {
+                        "originalText": "どうか",
+                        "transformedText": "どうか",
+                        "deinflectedText": "どうか",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG上級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "947㋕",
+                    "displayValueParsed": false,
+                    "frequency": 947,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4701㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1188㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1188,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "同化",
+                    "reading": "どうか",
+                    "sources": [
+                      {
+                        "originalText": "どうか",
+                        "transformedText": "どうか",
+                        "deinflectedText": "どうか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4701㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4701,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12447",
+                    "displayValueParsed": false,
+                    "frequency": 12447,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14423",
+                    "displayValueParsed": false,
+                    "frequency": 14423,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "120642㋕",
+                    "displayValueParsed": false,
+                    "frequency": 120642,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 19674,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "銅貨",
+                    "reading": "どうか",
+                    "sources": [
+                      {
+                        "originalText": "どうか",
+                        "transformedText": "どうか",
+                        "deinflectedText": "どうか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "16426",
+                    "displayValueParsed": false,
+                    "frequency": 16426,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "35758",
+                    "displayValueParsed": false,
+                    "frequency": 35758,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "368143㋕",
+                    "displayValueParsed": false,
+                    "frequency": 368143,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 45168,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "如何か",
+                    "reading": "どうか",
+                    "sources": [
+                      {
+                        "originalText": "どうか",
+                        "transformedText": "どうか",
+                        "deinflectedText": "どうか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1188㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1188,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "76254",
+                    "displayValueParsed": false,
+                    "frequency": 76254,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "同価",
+                    "reading": "どうか",
+                    "sources": [
+                      {
+                        "originalText": "どうか",
+                        "transformedText": "どうか",
+                        "deinflectedText": "どうか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "195947",
+                    "displayValueParsed": false,
+                    "frequency": 195947,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "241053",
+                    "displayValueParsed": false,
+                    "frequency": 241053,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "道家",
+                    "reading": "どうか",
+                    "sources": [
+                      {
+                        "originalText": "どうか",
+                        "transformedText": "どうか",
+                        "deinflectedText": "どうか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "91649",
+                    "displayValueParsed": false,
+                    "frequency": 91649,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "100373",
+                    "displayValueParsed": false,
+                    "frequency": 100373,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 62451,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "道歌",
+                    "reading": "どうか",
+                    "sources": [
+                      {
+                        "originalText": "どうか",
+                        "transformedText": "どうか",
+                        "deinflectedText": "どうか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "147685",
+                    "displayValueParsed": false,
+                    "frequency": 147685,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "166998",
+                    "displayValueParsed": false,
+                    "frequency": 166998,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 97150,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "銅戈",
+                    "reading": "どうか",
+                    "sources": [
+                      {
+                        "originalText": "どうか",
+                        "transformedText": "どうか",
+                        "deinflectedText": "どうか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "309225",
+                    "displayValueParsed": false,
+                    "frequency": 309225,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 105574,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 3,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "同課",
+                    "reading": "どうか",
+                    "sources": [
+                      {
+                        "originalText": "どうか",
+                        "transformedText": "どうか",
+                        "deinflectedText": "どうか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 35779,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "どう",
+                    "reading": "どう",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "どう",
+                        "deinflectedText": "どう",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "85㋕",
+                    "displayValueParsed": false,
+                    "frequency": 85,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "32301㋕",
+                    "displayValueParsed": false,
+                    "frequency": 32301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "32401㋕",
+                    "displayValueParsed": false,
+                    "frequency": 32401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "53㋕",
+                    "displayValueParsed": false,
+                    "frequency": 53,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 88,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "動",
+                    "reading": "どう",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "どう",
+                        "deinflectedText": "どう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10241",
+                    "displayValueParsed": false,
+                    "frequency": 10241,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10394",
+                    "displayValueParsed": false,
+                    "frequency": 10394,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 15453,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "同",
+                    "reading": "どう",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "どう",
+                        "deinflectedText": "どう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "4683",
+                    "displayValueParsed": false,
+                    "frequency": 4683,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6553",
+                    "displayValueParsed": false,
+                    "frequency": 6553,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1406,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "堂",
+                    "reading": "どう",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "どう",
+                        "deinflectedText": "どう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5844",
+                    "displayValueParsed": false,
+                    "frequency": 5844,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "32301㋕",
+                    "displayValueParsed": false,
+                    "frequency": 32301,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8466",
+                    "displayValueParsed": false,
+                    "frequency": 8466,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "113354㋕",
+                    "displayValueParsed": false,
+                    "frequency": 113354,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 6304,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "胴",
+                    "reading": "どう",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "どう",
+                        "deinflectedText": "どう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8871",
+                    "displayValueParsed": false,
+                    "frequency": 8871,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12808",
+                    "displayValueParsed": false,
+                    "frequency": 12808,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 25640,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "銅",
+                    "reading": "どう",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "どう",
+                        "deinflectedText": "どう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "15662",
+                    "displayValueParsed": false,
+                    "frequency": 15662,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23844",
+                    "displayValueParsed": false,
+                    "frequency": 23844,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "28720㋕",
+                    "displayValueParsed": false,
+                    "frequency": 28720,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11684,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "如何",
+                    "reading": "どう",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "どう",
+                        "deinflectedText": "どう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "85㋕",
+                    "displayValueParsed": false,
+                    "frequency": 85,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "17736",
+                    "displayValueParsed": false,
+                    "frequency": 17736,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "53㋕",
+                    "displayValueParsed": false,
+                    "frequency": 53,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "32585",
+                    "displayValueParsed": false,
+                    "frequency": 32585,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 32540,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 114541,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "仝",
+                    "reading": "どう",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "どう",
+                        "deinflectedText": "どう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "319995",
+                    "displayValueParsed": false,
+                    "frequency": 319995,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "洞",
+                    "reading": "どう",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "どう",
+                        "deinflectedText": "どう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "35535",
+                    "displayValueParsed": false,
+                    "frequency": 35535,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "30118",
+                    "displayValueParsed": false,
+                    "frequency": 30118,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 23829,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 124399,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "道",
+                    "reading": "どう",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "どう",
+                        "deinflectedText": "どう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "5401",
+                    "displayValueParsed": false,
+                    "frequency": 5401,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4567",
+                    "displayValueParsed": false,
+                    "frequency": 4567,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4216,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 104804,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -4,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "幢",
+                    "reading": "どう",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "どう",
+                        "deinflectedText": "どう",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 109203,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ドウ",
+                    "reading": "ドウ",
+                    "sources": [
+                      {
+                        "originalText": "どう",
+                        "transformedText": "ドウ",
+                        "deinflectedText": "ドウ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "47493㋕",
+                    "displayValueParsed": false,
+                    "frequency": 47493,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "102061㋕",
+                    "displayValueParsed": false,
+                    "frequency": 102061,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "146977㋕",
+                    "displayValueParsed": false,
+                    "frequency": 146977,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "213367㋕",
+                    "displayValueParsed": false,
+                    "frequency": 213367,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "132144㋕",
+                    "displayValueParsed": false,
+                    "frequency": 132144,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 19995,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ど",
+                    "reading": "ど",
+                    "sources": [
+                      {
+                        "originalText": "ど",
+                        "transformedText": "ど",
+                        "deinflectedText": "ど",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1598㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1598,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "680㋕",
+                    "displayValueParsed": false,
+                    "frequency": 680,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3503,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "度",
+                    "reading": "ど",
+                    "sources": [
+                      {
+                        "originalText": "ど",
+                        "transformedText": "ど",
+                        "deinflectedText": "ど",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1277",
+                    "displayValueParsed": false,
+                    "frequency": 1277,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "1683㋕",
+                    "displayValueParsed": false,
+                    "frequency": 1683,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2295",
+                    "displayValueParsed": false,
+                    "frequency": 2295,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 420,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 130035,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "努",
+                    "reading": "ど",
+                    "sources": [
+                      {
+                        "originalText": "ど",
+                        "transformedText": "ど",
+                        "deinflectedText": "ど",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "53319",
+                    "displayValueParsed": false,
+                    "frequency": 53319,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "140045",
+                    "displayValueParsed": false,
+                    "frequency": 140045,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "土",
+                    "reading": "ど",
+                    "sources": [
+                      {
+                        "originalText": "ど",
+                        "transformedText": "ど",
+                        "deinflectedText": "ど",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8801",
+                    "displayValueParsed": false,
+                    "frequency": 8801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "10870",
+                    "displayValueParsed": false,
+                    "frequency": 10870,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 823,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 112427,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "弩",
+                    "reading": "ど",
+                    "sources": [
+                      {
+                        "originalText": "ど",
+                        "transformedText": "ど",
+                        "deinflectedText": "ど",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "笯",
+                    "reading": "ど",
+                    "sources": [
+                      {
+                        "originalText": "ど",
+                        "transformedText": "ど",
+                        "deinflectedText": "ど",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "途",
+                    "reading": "ど",
+                    "sources": [
+                      {
+                        "originalText": "ど",
+                        "transformedText": "ど",
+                        "deinflectedText": "ど",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 146147,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ド",
+                    "reading": "ド",
+                    "sources": [
+                      {
+                        "originalText": "ど",
+                        "transformedText": "ド",
+                        "deinflectedText": "ド",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6000㋕",
+                    "displayValueParsed": false,
+                    "frequency": 6000,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "31687㋕",
+                    "displayValueParsed": false,
+                    "frequency": 31687,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2817㋕",
+                    "displayValueParsed": false,
+                    "frequency": 2817,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 30199,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 4
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "うかな",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "羽化",
+                    "reading": "うか",
+                    "sources": [
+                      {
+                        "originalText": "うか",
+                        "transformedText": "うか",
+                        "deinflectedText": "うか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "38324",
+                    "displayValueParsed": false,
+                    "frequency": 38324,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "39878",
+                    "displayValueParsed": false,
+                    "frequency": 39878,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "49279㋕",
+                    "displayValueParsed": false,
+                    "frequency": 49279,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 25839,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "雨下",
+                    "reading": "うか",
+                    "sources": [
+                      {
+                        "originalText": "うか",
+                        "transformedText": "うか",
+                        "deinflectedText": "うか",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "16341㋕",
+                    "displayValueParsed": false,
+                    "frequency": 16341,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "195721",
+                    "displayValueParsed": false,
+                    "frequency": 195721,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "204688",
+                    "displayValueParsed": false,
+                    "frequency": 204688,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 125248,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "う",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "206㋕",
+                    "displayValueParsed": false,
+                    "frequency": 206,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 9411,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "卯",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "40163",
+                    "displayValueParsed": false,
+                    "frequency": 40163,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "61505",
+                    "displayValueParsed": false,
+                    "frequency": 61505,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 55581,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 147477,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "宇",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "41402",
+                    "displayValueParsed": false,
+                    "frequency": 41402,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46946,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 159206,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "得",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "46669㋕",
+                    "displayValueParsed": false,
+                    "frequency": 46669,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "111527",
+                    "displayValueParsed": false,
+                    "frequency": 111527,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "有",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "33602",
+                    "displayValueParsed": false,
+                    "frequency": 33602,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "61060",
+                    "displayValueParsed": false,
+                    "frequency": 61060,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 18901,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 145835,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "竽",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "247924",
+                    "displayValueParsed": false,
+                    "frequency": 247924,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "279165",
+                    "displayValueParsed": false,
+                    "frequency": 279165,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "羽",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "62501",
+                    "displayValueParsed": false,
+                    "frequency": 62501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "117275",
+                    "displayValueParsed": false,
+                    "frequency": 117275,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 115134,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 122375,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鵜",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "31146",
+                    "displayValueParsed": false,
+                    "frequency": 31146,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "66994",
+                    "displayValueParsed": false,
+                    "frequency": 66994,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 35994,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "諾",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "鰻",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -104,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "兎",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "優",
+                    "reading": "う",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "う",
+                        "deinflectedText": "う",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 159848,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "ウ",
+                    "reading": "ウ",
+                    "sources": [
+                      {
+                        "originalText": "う",
+                        "transformedText": "ウ",
+                        "deinflectedText": "ウ",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18682㋕",
+                    "displayValueParsed": false,
+                    "frequency": 18682,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "71893㋕",
+                    "displayValueParsed": false,
+                    "frequency": 71893,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3466㋕",
+                    "displayValueParsed": false,
+                    "frequency": 3466,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 15980,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "かな",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "かな",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG上級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      },
+                      {
+                        "name": "DOJG中級編",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "130㋕",
+                    "displayValueParsed": false,
+                    "frequency": 130,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 24501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "115㋕",
+                    "displayValueParsed": false,
+                    "frequency": 115,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26541,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "仮名",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 24501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "34143",
+                    "displayValueParsed": false,
+                    "frequency": 34143,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15460㋕",
+                    "displayValueParsed": false,
+                    "frequency": 15460,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "41349",
+                    "displayValueParsed": false,
+                    "frequency": 41349,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11667,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 152435,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "哉",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "28150",
+                    "displayValueParsed": false,
+                    "frequency": 28150,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "45567",
+                    "displayValueParsed": false,
+                    "frequency": 45567,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 44835,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 144331,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "仮字",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 24501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "198295",
+                    "displayValueParsed": false,
+                    "frequency": 198295,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 155824,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -101,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "金",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "69180",
+                    "displayValueParsed": false,
+                    "frequency": 69180,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 57007,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -102,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "假名",
+                    "reading": "かな",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "かな",
+                        "deinflectedText": "かな",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "24501㋕",
+                    "displayValueParsed": false,
+                    "frequency": 24501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "250374",
+                    "displayValueParsed": false,
+                    "frequency": 250374,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "15460㋕",
+                    "displayValueParsed": false,
+                    "frequency": 15460,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "279165",
+                    "displayValueParsed": false,
+                    "frequency": 279165,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  [
+                    "convertHiraganaToKatakana"
+                  ]
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 5,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 2,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "Cana",
+                    "reading": "カナ",
+                    "sources": [
+                      {
+                        "originalText": "かな",
+                        "transformedText": "カナ",
+                        "deinflectedText": "カナ",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "か",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12㋕",
+                    "displayValueParsed": false,
+                    "frequency": 12,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "11㋕",
+                    "displayValueParsed": false,
+                    "frequency": 11,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 19,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "加",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "16448",
+                    "displayValueParsed": false,
+                    "frequency": 16448,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25781",
+                    "displayValueParsed": false,
+                    "frequency": 25781,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 26419,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "可",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "9467",
+                    "displayValueParsed": false,
+                    "frequency": 9467,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12633",
+                    "displayValueParsed": false,
+                    "frequency": 12633,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "57887㋕",
+                    "displayValueParsed": false,
+                    "frequency": 57887,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4319,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "科",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "6581",
+                    "displayValueParsed": false,
+                    "frequency": 6581,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "8555",
+                    "displayValueParsed": false,
+                    "frequency": 8555,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3512,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 152614,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "蚊",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "12258",
+                    "displayValueParsed": false,
+                    "frequency": 12258,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "12952",
+                    "displayValueParsed": false,
+                    "frequency": 12952,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 8283,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "課",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8436",
+                    "displayValueParsed": false,
+                    "frequency": 8436,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "6393",
+                    "displayValueParsed": false,
+                    "frequency": 6393,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "69624㋕",
+                    "displayValueParsed": false,
+                    "frequency": 69624,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 5002,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "下",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2801",
+                    "displayValueParsed": false,
+                    "frequency": 2801,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3986",
+                    "displayValueParsed": false,
+                    "frequency": 3986,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 2971,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 105800,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "佳",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "36202",
+                    "displayValueParsed": false,
+                    "frequency": 36202,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47931",
+                    "displayValueParsed": false,
+                    "frequency": 47931,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "価",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "73601",
+                    "displayValueParsed": false,
+                    "frequency": 73601,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "47025",
+                    "displayValueParsed": false,
+                    "frequency": 47025,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 21934,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 153400,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "化",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "2672",
+                    "displayValueParsed": false,
+                    "frequency": 2672,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "2336",
+                    "displayValueParsed": false,
+                    "frequency": 2336,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 761,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "夏",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "58901",
+                    "displayValueParsed": false,
+                    "frequency": 58901,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "164018",
+                    "displayValueParsed": false,
+                    "frequency": 164018,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 28065,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "家",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3313",
+                    "displayValueParsed": false,
+                    "frequency": 3313,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 3876,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 95167,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "寡",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "149762",
+                    "displayValueParsed": false,
+                    "frequency": 149762,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "戈",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "99657",
+                    "displayValueParsed": false,
+                    "frequency": 99657,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "115591",
+                    "displayValueParsed": false,
+                    "frequency": 115591,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 119581,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 141501,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "日",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "21101",
+                    "displayValueParsed": false,
+                    "frequency": 21101,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "7733",
+                    "displayValueParsed": false,
+                    "frequency": 7733,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 56,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 76112,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "果",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "19261",
+                    "displayValueParsed": false,
+                    "frequency": 19261,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25313",
+                    "displayValueParsed": false,
+                    "frequency": 25313,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 114501,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "架",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "29508",
+                    "displayValueParsed": false,
+                    "frequency": 29508,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "41525",
+                    "displayValueParsed": false,
+                    "frequency": 41525,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 46930,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "火",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "10501",
+                    "displayValueParsed": false,
+                    "frequency": 10501,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "13005",
+                    "displayValueParsed": false,
+                    "frequency": 13005,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 24360,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 146483,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "禍",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "実用日本語表現辞典",
+                    "dictionaryAlias": "実用日本語表現辞典"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "28455",
+                    "displayValueParsed": false,
+                    "frequency": 28455,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 97819,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 109488,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "箇",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "109501",
+                    "displayValueParsed": false,
+                    "frequency": 109501,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "荷",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "135702",
+                    "displayValueParsed": false,
+                    "frequency": 135702,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "347844",
+                    "displayValueParsed": false,
+                    "frequency": 347844,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "菓",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "68334",
+                    "displayValueParsed": false,
+                    "frequency": 68334,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "58453",
+                    "displayValueParsed": false,
+                    "frequency": 58453,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "華",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "20802",
+                    "displayValueParsed": false,
+                    "frequency": 20802,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "25748",
+                    "displayValueParsed": false,
+                    "frequency": 25748,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 49439,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 132548,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "過",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "16909",
+                    "displayValueParsed": false,
+                    "frequency": 16909,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "20624",
+                    "displayValueParsed": false,
+                    "frequency": 20624,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11225,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 158292,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "顆",
+                    "reading": "か",
+                    "sources": [
+                      {
+                        "originalText": "か",
+                        "transformedText": "か",
+                        "deinflectedText": "か",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "101577",
+                    "displayValueParsed": false,
+                    "frequency": 101577,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "113320",
+                    "displayValueParsed": false,
+                    "frequency": 113320,
+                    "dictionaryIndex": 3
+                  }
+                ]
+              }
+            ],
+            "originalTextLength": 2
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "な",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "な",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [
+                      {
+                        "name": "DOJG基本",
+                        "category": "default",
+                        "order": 0,
+                        "score": 0,
+                        "content": [],
+                        "dictionaries": [
+                          "日本語文法辞典(全集)"
+                        ],
+                        "redundant": false
+                      }
+                    ],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  },
+                  {
+                    "dictionary": "日本語文法辞典(全集)",
+                    "dictionaryAlias": "日本語文法辞典(全集)"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "26㋕",
+                    "displayValueParsed": false,
+                    "frequency": 26,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 89,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "名",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "664",
+                    "displayValueParsed": false,
+                    "frequency": 664,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "835",
+                    "displayValueParsed": false,
+                    "frequency": 835,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "14368㋕",
+                    "displayValueParsed": false,
+                    "frequency": 14368,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 1813,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 137968,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "菜",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [
+                  {
+                    "dictionary": "NHK",
+                    "dictionaryAlias": "NHK"
+                  }
+                ],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "18106",
+                    "displayValueParsed": false,
+                    "frequency": 18106,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "21850",
+                    "displayValueParsed": false,
+                    "frequency": 21850,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 22974,
+                    "dictionaryIndex": 4
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 143251,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "儺",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "84943",
+                    "displayValueParsed": false,
+                    "frequency": 84943,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "108965",
+                    "displayValueParsed": false,
+                    "frequency": 108965,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 130367,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "己",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "algorithm",
+                    "inflectionRules": []
+                  }
+                ],
+                "score": -1,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 0,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "汝",
+                    "reading": "な",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "な",
+                        "matchType": "exact",
+                        "matchSource": "reading",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "8445",
+                    "displayValueParsed": false,
+                    "frequency": 8445,
+                    "dictionaryIndex": 2
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "dictionary",
+                    "inflectionRules": [
+                      {
+                        "name": "redirected from な"
+                      }
+                    ]
+                  }
+                ],
+                "score": 200,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "七",
+                    "reading": "しち",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "七",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "3638",
+                    "displayValueParsed": false,
+                    "frequency": 3638,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "23782㋕",
+                    "displayValueParsed": false,
+                    "frequency": 23782,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 11209,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "dictionary",
+                    "inflectionRules": [
+                      {
+                        "name": "redirected from な"
+                      }
+                    ]
+                  }
+                ],
+                "score": 197,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "七",
+                    "reading": "なな",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "七",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": [
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "1477",
+                    "displayValueParsed": false,
+                    "frequency": 1477,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "JPDBv2㋕",
+                    "dictionaryAlias": "JPDBv2㋕",
+                    "headwordIndex": 0,
+                    "displayValue": "13298㋕",
+                    "displayValueParsed": false,
+                    "frequency": 13298,
+                    "dictionaryIndex": 2
+                  },
+                  {
+                    "dictionary": "Jiten",
+                    "dictionaryAlias": "Jiten",
+                    "headwordIndex": 0,
+                    "displayValue": "4003㋕",
+                    "displayValueParsed": false,
+                    "frequency": 4003,
+                    "dictionaryIndex": 3
+                  },
+                  {
+                    "dictionary": "CC100",
+                    "dictionaryAlias": "CC100",
+                    "headwordIndex": 0,
+                    "displayValue": null,
+                    "displayValueParsed": false,
+                    "frequency": 4828,
+                    "dictionaryIndex": 4
+                  }
+                ]
+              },
+              {
+                "type": "term",
+                "isPrimary": true,
+                "textProcessorRuleChainCandidates": [
+                  []
+                ],
+                "inflectionRuleChainCandidates": [
+                  {
+                    "source": "dictionary",
+                    "inflectionRules": [
+                      {
+                        "name": "redirected from な"
+                      }
+                    ]
+                  }
+                ],
+                "score": 0,
+                "frequencyOrder": 0,
+                "dictionaryIndex": 0,
+                "dictionaryAlias": "",
+                "sourceTermExactMatchCount": 1,
+                "matchPrimaryReading": false,
+                "maxOriginalTextLength": 1,
+                "headwords": [
+                  {
+                    "index": 0,
+                    "headwordIndex": 0,
+                    "term": "七",
+                    "reading": "チー",
+                    "sources": [
+                      {
+                        "originalText": "な",
+                        "transformedText": "な",
+                        "deinflectedText": "七",
+                        "matchType": "exact",
+                        "matchSource": "term",
+                        "isPrimary": true
+                      }
+                    ],
+                    "tags": [],
+                    "wordClasses": []
+                  }
+                ],
+                "definitions": [
+                  {
+                    "dictionary": "Jitendex.org [2026-03-05]",
+                    "dictionaryAlias": "Jitendex.org [2026-03-05]"
+                  }
+                ],
+                "pronunciations": [],
+                "frequencies": []
+              }
+            ],
+            "originalTextLength": 1
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "～ん…どうかな",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [],
+            "originalTextLength": 0
+          }
+        }
+      },
+      {
+        "action": "termsFind",
+        "params": {
+          "text": "…どうかな",
+          "details": {
+            "matchType": "exact",
+            "deinflect": true
+          },
+          "optionsContext": {
+            "index": 0
+          }
+        },
+        "response": {
+          "result": {
+            "dictionaryEntries": [],
+            "originalTextLength": 0
+          }
+        }
+      },
+      {
+        "action": "getTermFrequencies",
+        "params": {
+          "termReadingList": [
+            {
+              "term": "ぅ～",
+              "reading": null
+            },
+            {
+              "term": "ん",
+              "reading": "ん"
+            },
+            {
+              "term": "どうかな",
+              "reading": "どうかな"
+            }
+          ],
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ]
+        },
+        "response": {
+          "result": [
+            {
+              "term": "ん",
+              "reading": "ん",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 54,
+              "displayValue": "54㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "ん",
+              "reading": "ん",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 34001,
+              "displayValue": "34001㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "ん",
+              "reading": "ん",
+              "dictionary": "CC100",
+              "hasReading": true,
+              "frequency": 132,
+              "displayValue": null,
+              "displayValueParsed": false
+            },
+            {
+              "term": "ん",
+              "reading": "ん",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 21,
+              "displayValue": "21㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "どうかな",
+              "reading": "どうかな",
+              "dictionary": "JPDBv2㋕",
+              "hasReading": false,
+              "frequency": 3439,
+              "displayValue": "3439㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            },
+            {
+              "term": "どうかな",
+              "reading": "どうかな",
+              "dictionary": "Jiten",
+              "hasReading": false,
+              "frequency": 1610,
+              "displayValue": "1610㋕",
+              "displayValueParsed": false,
+              "frequencyMode": "rank-based"
+            }
+          ]
+        }
+      }
+    ],
+    "scripts": [
+      {
+        "sha256": "fb64f047eb0494f136bb92311df43c5318873298fe3efad6bfa82e5d531a93e1",
+        "marker": "optionsGetFull",
+        "result": {
+          "profileIndex": 0,
+          "scanLength": 21,
+          "dictionaries": [
+            "Jitendex.org [2026-03-05]",
+            "日本語文法辞典(全集)",
+            "JPDBv2㋕",
+            "Jiten",
+            "CC100",
+            "実用日本語表現辞典",
+            "NHK",
+            "SubMiner Character Dictionary"
+          ],
+          "dictionaryPriorityByName": {
+            "Jitendex.org [2026-03-05]": 0,
+            "日本語文法辞典(全集)": 1,
+            "JPDBv2㋕": 2,
+            "Jiten": 3,
+            "CC100": 4,
+            "実用日本語表現辞典": 5,
+            "NHK": 6,
+            "SubMiner Character Dictionary": 7
+          },
+          "dictionaryFrequencyModeByName": {
+            "JPDBv2㋕": "rank-based",
+            "Jiten": "rank-based"
+          }
+        }
+      },
+      {
+        "sha256": "7eb1a7afd89ae0ca2bb2d148d7cc3ccc1959c15ee9bea53fae9f03801642b075",
+        "marker": "parseText",
+        "result": [
+          {
+            "id": "scan",
+            "source": "scanning-parser",
+            "dictionary": null,
+            "index": 0,
+            "content": [
+              [
+                {
+                  "text": "ぅ～",
+                  "reading": ""
+                }
+              ],
+              [
+                {
+                  "text": "ん",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "ん",
+                        "reading": "ん",
+                        "sources": [
+                          {
+                            "originalText": "ん",
+                            "transformedText": "ん",
+                            "deinflectedText": "ん",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "ん",
+                        "reading": "ん",
+                        "sources": [
+                          {
+                            "originalText": "ん",
+                            "transformedText": "ん",
+                            "deinflectedText": "ん",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "ん",
+                        "reading": "ん",
+                        "sources": [
+                          {
+                            "originalText": "ん",
+                            "transformedText": "ん",
+                            "deinflectedText": "ん",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "ん",
+                        "reading": "ん",
+                        "sources": [
+                          {
+                            "originalText": "ん",
+                            "transformedText": "ん",
+                            "deinflectedText": "ん",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ],
+                    [
+                      {
+                        "term": "ン",
+                        "reading": "ン",
+                        "sources": [
+                          {
+                            "originalText": "ん",
+                            "transformedText": "ン",
+                            "deinflectedText": "ン",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ],
+              [
+                {
+                  "text": "…",
+                  "reading": ""
+                }
+              ],
+              [
+                {
+                  "text": "どうかな",
+                  "reading": "",
+                  "headwords": [
+                    [
+                      {
+                        "term": "どうかな",
+                        "reading": "どうかな",
+                        "sources": [
+                          {
+                            "originalText": "どうかな",
+                            "transformedText": "どうかな",
+                            "deinflectedText": "どうかな",
+                            "matchType": "exact",
+                            "matchSource": "term",
+                            "isPrimary": true
+                          }
+                        ],
+                        "frequencies": []
+                      }
+                    ]
+                  ]
+                }
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "sha256": "a09de9456aff07f76732bb731d1b0eb475ec72cdaac8b7421e2057f990cef583",
+        "marker": "termsFind",
+        "result": [
+          {
+            "surface": "ん",
+            "reading": "ん",
+            "headword": "ん",
+            "headwordReading": "ん",
+            "startPos": 2,
+            "endPos": 3,
+            "isNameMatch": false,
+            "frequencyRank": 54
+          },
+          {
+            "surface": "どうかな",
+            "reading": "どうかな",
+            "headword": "どうかな",
+            "headwordReading": "どうかな",
+            "startPos": 4,
+            "endPos": 8,
+            "isNameMatch": false,
+            "frequencyRank": 3439
+          }
+        ]
+      },
+      {
+        "sha256": "9c562e9fe5afafce42da64a722c09de551f58a693c231754836e984fefbfcd88",
+        "marker": "getTermFrequencies",
+        "result": [
+          {
+            "term": "ん",
+            "reading": "ん",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 54,
+            "displayValue": "54㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "ん",
+            "reading": "ん",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 34001,
+            "displayValue": "34001㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "ん",
+            "reading": "ん",
+            "dictionary": "CC100",
+            "hasReading": true,
+            "frequency": 132,
+            "displayValue": null,
+            "displayValueParsed": false
+          },
+          {
+            "term": "ん",
+            "reading": "ん",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 21,
+            "displayValue": "21㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "どうかな",
+            "reading": "どうかな",
+            "dictionary": "JPDBv2㋕",
+            "hasReading": false,
+            "frequency": 3439,
+            "displayValue": "3439㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          },
+          {
+            "term": "どうかな",
+            "reading": "どうかな",
+            "dictionary": "Jiten",
+            "hasReading": false,
+            "frequency": 1610,
+            "displayValue": "1610㋕",
+            "displayValueParsed": false,
+            "frequencyMode": "rank-based"
+          }
+        ]
+      }
+    ],
+    "mecab": {
+      "ぅ～ん…どうかな": [
+        {
+          "word": "ぅ",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "一般",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "ぅ",
+          "katakanaReading": "",
+          "pronunciation": ""
+        },
+        {
+          "word": "～",
+          "partOfSpeech": "noun",
+          "pos1": "名詞",
+          "pos2": "サ変接続",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "～",
+          "katakanaReading": "",
+          "pronunciation": ""
+        },
+        {
+          "word": "ん",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "格助詞",
+          "pos3": "一般",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "ん",
+          "katakanaReading": "ン",
+          "pronunciation": "ン"
+        },
+        {
+          "word": "…",
+          "partOfSpeech": "symbol",
+          "pos1": "記号",
+          "pos2": "一般",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "…",
+          "katakanaReading": "…",
+          "pronunciation": "…"
+        },
+        {
+          "word": "どう",
+          "partOfSpeech": "other",
+          "pos1": "副詞",
+          "pos2": "助詞類接続",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "どう",
+          "katakanaReading": "ドウ",
+          "pronunciation": "ドー"
+        },
+        {
+          "word": "か",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "副助詞／並立助詞／終助詞",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "か",
+          "katakanaReading": "カ",
+          "pronunciation": "カ"
+        },
+        {
+          "word": "な",
+          "partOfSpeech": "particle",
+          "pos1": "助詞",
+          "pos2": "終助詞",
+          "pos3": "*",
+          "pos4": "*",
+          "inflectionType": "*",
+          "inflectionForm": "*",
+          "headword": "な",
+          "katakanaReading": "ナ",
+          "pronunciation": "ナ"
+        }
+      ]
+    }
+  },
+  "expected": {
+    "tokens": [
+      {
+        "surface": "ぅ～",
+        "reading": "",
+        "headword": "ぅ～",
+        "startPos": 0,
+        "endPos": 2,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "pos1": "名詞",
+        "pos2": "一般|サ変接続",
+        "pos3": "*",
+        "isUnparsedRun": true
+      },
+      {
+        "surface": "ん",
+        "reading": "ん",
+        "headword": "ん",
+        "startPos": 2,
+        "endPos": 3,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "ん",
+        "pos1": "助詞",
+        "pos2": "格助詞",
+        "pos3": "一般"
+      },
+      {
+        "surface": "どうかな",
+        "reading": "どうかな",
+        "headword": "どうかな",
+        "startPos": 4,
+        "endPos": 8,
+        "partOfSpeech": "other",
+        "isKnown": false,
+        "isNPlusOneTarget": false,
+        "headwordReading": "どうかな",
+        "pos1": "副詞|助詞",
+        "pos2": "助詞類接続|副助詞／並立助詞／終助詞|終助詞",
+        "pos3": "*",
+        "frequencyRank": 3439
+      }
+    ]
+  }
+}

--- a/src/core/services/tokenizer/golden-corpus-harness.ts
+++ b/src/core/services/tokenizer/golden-corpus-harness.ts
@@ -1,0 +1,475 @@
+import { createHash } from 'node:crypto';
+import vm from 'node:vm';
+import type {
+  FrequencyDictionaryMatchMode,
+  JlptLevel,
+  MergedToken,
+  NPlusOneMatchMode,
+  PartOfSpeech,
+  Token,
+} from '../../../types';
+import { createTokenizerDepsRuntime } from '../tokenizer';
+import type { TokenizerServiceDeps } from '../tokenizer';
+import { enrichTokensWithMecabPos1 } from './parser-enrichment-stage';
+
+// Golden-corpus fixtures capture a real subtitle line, the raw Yomitan
+// backend responses (chrome.runtime.sendMessage level) and raw MeCab tokens
+// observed while tokenizing it live, plus the annotated tokens the full
+// pipeline produced. Replay runs the real injected scanning scripts in a vm
+// against the recorded responses, so merge/enrichment/annotation/filtering
+// are exercised end-to-end without Electron or dictionaries.
+
+export interface GoldenFixtureKnownWord {
+  text: string;
+  reading?: string;
+}
+
+export interface GoldenFixtureConfig {
+  knownWords?: Array<string | GoldenFixtureKnownWord>;
+  knownWordMatchMode?: NPlusOneMatchMode;
+  jlptLevels?: Record<string, JlptLevel>;
+  localFrequencyRanks?: Record<string, number>;
+  knownWordsEnabled?: boolean;
+  nPlusOneEnabled?: boolean;
+  jlptEnabled?: boolean;
+  nameMatchEnabled?: boolean;
+  frequencyEnabled?: boolean;
+  frequencyMatchMode?: FrequencyDictionaryMatchMode;
+  minSentenceWordsForNPlusOne?: number;
+}
+
+export interface GoldenRecordedMessage {
+  action: string;
+  params: unknown;
+  /** Raw response object the page callback received: { result } or { error }. */
+  response: unknown;
+}
+
+export interface GoldenRecordedScript {
+  sha256: string;
+  /** Short classification of the script, for debugging only. */
+  marker: string;
+  result: unknown;
+}
+
+export interface GoldenFixtureRecording {
+  messages: GoldenRecordedMessage[];
+  scripts: GoldenRecordedScript[];
+  /** Raw MeCab tokens keyed by the exact text passed to tokenizeWithMecab. */
+  mecab: Record<string, Token[] | null>;
+}
+
+export interface GoldenExpectedToken {
+  surface: string;
+  reading: string;
+  headword: string;
+  headwordReading?: string;
+  startPos: number;
+  endPos: number;
+  partOfSpeech: PartOfSpeech;
+  pos1?: string;
+  pos2?: string;
+  pos3?: string;
+  isKnown: boolean;
+  isNPlusOneTarget: boolean;
+  isNameMatch?: true;
+  isUnparsedRun?: true;
+  jlptLevel?: JlptLevel;
+  frequencyRank?: number;
+}
+
+export interface GoldenFixture {
+  name: string;
+  description?: string;
+  issueRefs?: string[];
+  recordedAt?: string;
+  input: { text: string };
+  config: GoldenFixtureConfig;
+  recording: GoldenFixtureRecording;
+  expected: { tokens: GoldenExpectedToken[] | null };
+}
+
+// Only these backend actions are requested by the scanning/frequency scripts;
+// everything else in the recorded page traffic is Yomitan's own chatter.
+const GOLDEN_MESSAGE_ACTIONS: ReadonlySet<string> = new Set([
+  'optionsGetFull',
+  'getDictionaryInfo',
+  'parseText',
+  'termsFind',
+  'getTermFrequencies',
+]);
+
+// Field candidates appendDictionaryNames() in the injected helpers reads off
+// definitions/pronunciations — the only reason those arrays are consulted.
+const DICTIONARY_NAME_FIELDS = [
+  'dictionary',
+  'dictionaryName',
+  'name',
+  'title',
+  'dictionaryTitle',
+  'dictionaryAlias',
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function pruneToDictionaryNameFields(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const pruned: Record<string, unknown> = {};
+  for (const field of DICTIONARY_NAME_FIELDS) {
+    if (typeof value[field] === 'string') {
+      pruned[field] = value[field];
+    }
+  }
+  return pruned;
+}
+
+// Fields getBestFrequencyRank() and the frequency grouping helpers read off a
+// termsFind frequency item, beyond the dictionary-name candidates.
+const FREQUENCY_ITEM_FIELDS = [
+  'headwordIndex',
+  'displayValue',
+  'displayValueParsed',
+  'frequency',
+  'dictionaryIndex',
+  'term',
+  'reading',
+] as const;
+
+function pruneFrequencyItem(item: unknown): unknown {
+  if (!isRecord(item)) {
+    return item;
+  }
+  const pruned = pruneToDictionaryNameFields(item) as Record<string, unknown>;
+  for (const field of FREQUENCY_ITEM_FIELDS) {
+    if (item[field] !== undefined) {
+      pruned[field] = item[field];
+    }
+  }
+  return pruned;
+}
+
+function pruneTermsFindEntry(entry: unknown): unknown {
+  if (!isRecord(entry)) {
+    return entry;
+  }
+  const pruned: Record<string, unknown> = { ...entry };
+  if (Array.isArray(entry.definitions)) {
+    pruned.definitions = entry.definitions.map(pruneToDictionaryNameFields);
+  }
+  if (Array.isArray(entry.pronunciations)) {
+    pruned.pronunciations = entry.pronunciations.map(pruneToDictionaryNameFields);
+  }
+  if (Array.isArray(entry.frequencies)) {
+    pruned.frequencies = entry.frequencies.map(pruneFrequencyItem);
+  }
+  return pruned;
+}
+
+function pruneMessageResult(action: string, result: unknown): unknown {
+  if (action === 'optionsGetFull' && isRecord(result)) {
+    const profiles = Array.isArray(result.profiles) ? result.profiles : [];
+    return {
+      profileCurrent: result.profileCurrent,
+      profiles: profiles.map((profile) => {
+        if (!isRecord(profile) || !isRecord(profile.options)) {
+          return {};
+        }
+        const options = profile.options;
+        return {
+          options: {
+            scanning: isRecord(options.scanning) ? { length: options.scanning.length } : {},
+            dictionaries: Array.isArray(options.dictionaries)
+              ? options.dictionaries.map((dictionary) =>
+                  isRecord(dictionary)
+                    ? {
+                        name: dictionary.name,
+                        enabled: dictionary.enabled,
+                        id: dictionary.id,
+                      }
+                    : {},
+                )
+              : [],
+          },
+        };
+      }),
+    };
+  }
+  if (action === 'getDictionaryInfo' && Array.isArray(result)) {
+    return result.map((entry) =>
+      isRecord(entry) ? { title: entry.title, frequencyMode: entry.frequencyMode } : {},
+    );
+  }
+  if (action === 'termsFind' && isRecord(result) && Array.isArray(result.dictionaryEntries)) {
+    return {
+      ...result,
+      dictionaryEntries: result.dictionaryEntries.map(pruneTermsFindEntry),
+    };
+  }
+  return result;
+}
+
+// Strip recorded page traffic down to what replay can ever request: drop
+// Yomitan's own background messages and the heavyweight response fields
+// (definition glossaries, full options blobs) the injected helpers never read.
+// Prune safety is verified by the replay tests themselves — a pruned fixture
+// must still reproduce its recorded expectation.
+export function pruneGoldenMessages(messages: GoldenRecordedMessage[]): GoldenRecordedMessage[] {
+  return messages
+    .filter((message) => GOLDEN_MESSAGE_ACTIONS.has(message.action))
+    .map((message) => {
+      if (isRecord(message.response) && 'result' in message.response) {
+        return {
+          ...message,
+          response: {
+            ...message.response,
+            result: pruneMessageResult(message.action, message.response.result),
+          },
+        };
+      }
+      return message;
+    });
+}
+
+export function hashInjectedScript(script: string): string {
+  return createHash('sha256').update(script).digest('hex');
+}
+
+export function classifyInjectedScript(script: string): string {
+  const markers = [
+    'optionsGetFull',
+    'parseText',
+    'termsFind',
+    'getTermFrequencies',
+    'setAllSettings',
+  ];
+  const found = markers.filter((marker) => script.includes(marker));
+  return found.length > 0 ? found.join('+') : 'unknown';
+}
+
+function stableStringify(value: unknown): string {
+  // Recorded params pass through JSON, which turns undefined into null.
+  return JSON.stringify(value ?? null, (_key, entry: unknown) => {
+    if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+      const record = entry as Record<string, unknown>;
+      const sorted: Record<string, unknown> = {};
+      for (const key of Object.keys(record).sort()) {
+        sorted[key] = record[key];
+      }
+      return sorted;
+    }
+    return entry;
+  });
+}
+
+export interface FixtureLookups {
+  isKnownWord: (
+    text: string,
+    reading?: string,
+    options?: { allowReadingOnlyMatch?: boolean },
+  ) => boolean;
+  getJlptLevel: (text: string) => JlptLevel | null;
+  getFrequencyRank: (term: string) => number | null;
+}
+
+// Deliberately simple known-word semantics (exact text, optional reading
+// constraint) shared by the recorder and the replay harness so both sides of
+// a fixture agree. The production reading-aware cache is exercised by its own
+// unit tests, not by the golden corpus.
+export function buildFixtureLookups(config: GoldenFixtureConfig): FixtureLookups {
+  const readingsByText = new Map<string, Set<string> | null>();
+  for (const entry of config.knownWords ?? []) {
+    const text = typeof entry === 'string' ? entry : entry.text;
+    const reading = typeof entry === 'string' ? undefined : entry.reading;
+    if (!reading) {
+      readingsByText.set(text, null);
+      continue;
+    }
+    const existing = readingsByText.get(text);
+    if (existing === null) {
+      continue;
+    }
+    const readings = existing ?? new Set<string>();
+    readings.add(reading);
+    readingsByText.set(text, readings);
+  }
+
+  return {
+    isKnownWord: (text, reading) => {
+      if (!readingsByText.has(text)) {
+        return false;
+      }
+      const readings = readingsByText.get(text);
+      if (readings === null || readings === undefined) {
+        return true;
+      }
+      return reading === undefined || readings.has(reading);
+    },
+    getJlptLevel: (text) => config.jlptLevels?.[text] ?? null,
+    getFrequencyRank: (term) => config.localFrequencyRanks?.[term] ?? null,
+  };
+}
+
+// Config-driven deps getters shared by the recorder and the replay harness so
+// a fixture is tokenized under identical toggles in both directions.
+export function fixtureConfigGetters(config: GoldenFixtureConfig) {
+  return {
+    getKnownWordMatchMode: () => config.knownWordMatchMode ?? ('headword' as NPlusOneMatchMode),
+    getKnownWordsEnabled: () => config.knownWordsEnabled !== false,
+    getNPlusOneEnabled: () => config.nPlusOneEnabled !== false,
+    getJlptEnabled: () => config.jlptEnabled !== false,
+    getNameMatchEnabled: () => config.nameMatchEnabled !== false,
+    getNameMatchImagesEnabled: () => false,
+    getFrequencyDictionaryEnabled: () => config.frequencyEnabled !== false,
+    getFrequencyDictionaryMatchMode: () =>
+      config.frequencyMatchMode ?? ('headword' as FrequencyDictionaryMatchMode),
+    getMinSentenceWordsForNPlusOne: () => config.minSentenceWordsForNPlusOne ?? 3,
+  };
+}
+
+interface ReplayMessageEntry extends GoldenRecordedMessage {
+  used: boolean;
+  paramsKey: string;
+}
+
+export interface ReplayMessageStore {
+  handle: (action: string, params: unknown) => unknown;
+  unusedCount: () => number;
+}
+
+export function createReplayMessageStore(messages: GoldenRecordedMessage[]): ReplayMessageStore {
+  const entries: ReplayMessageEntry[] = messages.map((message) => ({
+    ...message,
+    used: false,
+    paramsKey: stableStringify(message.params),
+  }));
+
+  return {
+    handle: (action, params) => {
+      const paramsKey = stableStringify(params);
+      const match =
+        entries.find((e) => !e.used && e.action === action && e.paramsKey === paramsKey) ??
+        entries.find((e) => !e.used && e.action === action) ??
+        entries.find((e) => e.action === action && e.paramsKey === paramsKey);
+      if (!match) {
+        throw new Error(
+          `golden fixture replay: no recorded response for action "${action}" params=${paramsKey}`,
+        );
+      }
+      match.used = true;
+      return match.response;
+    },
+    unusedCount: () => entries.filter((e) => !e.used).length,
+  };
+}
+
+async function runInjectedScriptInVm(script: string, store: ReplayMessageStore): Promise<unknown> {
+  return await vm.runInNewContext(script, {
+    chrome: {
+      runtime: {
+        lastError: null,
+        sendMessage: (
+          payload: { action?: string; params?: unknown },
+          callback: (response: unknown) => void,
+        ) => {
+          callback(store.handle(payload.action ?? '', payload.params));
+        },
+      },
+    },
+    Array,
+    Boolean,
+    Date,
+    Error,
+    JSON,
+    Map,
+    Math,
+    Number,
+    Object,
+    Promise,
+    RegExp,
+    Set,
+    String,
+  });
+}
+
+export function createReplayTokenizerDeps(fixture: GoldenFixture): TokenizerServiceDeps {
+  const store = createReplayMessageStore(fixture.recording.messages);
+  const scriptResults = new Map(
+    fixture.recording.scripts.map((entry) => [entry.sha256, entry] as const),
+  );
+
+  const parserWindow = {
+    isDestroyed: () => false,
+    webContents: {
+      executeJavaScript: async (script: string) => {
+        try {
+          return await runInjectedScriptInVm(script, store);
+        } catch (vmError) {
+          const recorded = scriptResults.get(hashInjectedScript(script));
+          if (recorded) {
+            return recorded.result;
+          }
+          throw new Error(
+            `golden fixture "${fixture.name}": injected script (${classifyInjectedScript(script)}) failed in vm replay and has no recorded script-level result: ${(vmError as Error).message}`,
+          );
+        }
+      },
+    },
+  };
+
+  const lookups = buildFixtureLookups(fixture.config);
+  const deps = createTokenizerDepsRuntime({
+    getYomitanExt: () => ({ id: 'golden-fixture-extension' }) as never,
+    getYomitanParserWindow: () => parserWindow as never,
+    setYomitanParserWindow: () => undefined,
+    getYomitanParserReadyPromise: () => null,
+    setYomitanParserReadyPromise: () => undefined,
+    getYomitanParserInitPromise: () => null,
+    setYomitanParserInitPromise: () => undefined,
+    isKnownWord: lookups.isKnownWord,
+    getJlptLevel: lookups.getJlptLevel,
+    getFrequencyRank: lookups.getFrequencyRank,
+    ...fixtureConfigGetters(fixture.config),
+    getMecabTokenizer: () => ({
+      tokenize: async (text: string) => fixture.recording.mecab[text] ?? null,
+    }),
+  });
+
+  return {
+    ...deps,
+    // Pin the synchronous enrichment stage so record and replay share one
+    // implementation and no worker spawns inside bun test.
+    enrichTokensWithMecab: async (tokens, mecabTokens) =>
+      enrichTokensWithMecabPos1(tokens, mecabTokens),
+  };
+}
+
+export function projectGoldenTokens(tokens: MergedToken[] | null): GoldenExpectedToken[] | null {
+  if (!tokens) {
+    return null;
+  }
+  return tokens.map((token) => {
+    const projected: GoldenExpectedToken = {
+      surface: token.surface,
+      reading: token.reading,
+      headword: token.headword,
+      startPos: token.startPos,
+      endPos: token.endPos,
+      partOfSpeech: token.partOfSpeech,
+      isKnown: token.isKnown,
+      isNPlusOneTarget: token.isNPlusOneTarget,
+    };
+    if (token.headwordReading !== undefined) projected.headwordReading = token.headwordReading;
+    if (token.pos1 !== undefined) projected.pos1 = token.pos1;
+    if (token.pos2 !== undefined) projected.pos2 = token.pos2;
+    if (token.pos3 !== undefined) projected.pos3 = token.pos3;
+    if (token.isNameMatch === true) projected.isNameMatch = true;
+    if (token.isUnparsedRun === true) projected.isUnparsedRun = true;
+    if (token.jlptLevel !== undefined) projected.jlptLevel = token.jlptLevel;
+    if (token.frequencyRank !== undefined) projected.frequencyRank = token.frequencyRank;
+    return projected;
+  });
+}

--- a/src/core/services/tokenizer/golden-corpus.test.ts
+++ b/src/core/services/tokenizer/golden-corpus.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { tokenizeSubtitle } from '../tokenizer';
+import {
+  createReplayTokenizerDeps,
+  projectGoldenTokens,
+  type GoldenFixture,
+} from './golden-corpus-harness';
+
+// End-to-end regression corpus: each fixture replays recorded Yomitan backend
+// responses and raw MeCab tokens through the real tokenizeSubtitle pipeline
+// (scan-token merge, MeCab enrichment, frequency ranks, annotation stage,
+// noise suppression) and asserts the final annotated tokens.
+//
+// Record new fixtures with:
+//   bun run record-tokenizer-fixture:electron -- --name <slug> <text>
+// See __fixtures__/golden/README.md for the format and options.
+
+const FIXTURE_DIR = path.join(__dirname, '__fixtures__', 'golden');
+
+function loadFixtures(): GoldenFixture[] {
+  if (!fs.existsSync(FIXTURE_DIR)) {
+    return [];
+  }
+  return fs
+    .readdirSync(FIXTURE_DIR)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort()
+    .map((entry) => {
+      const filePath = path.join(FIXTURE_DIR, entry);
+      const fixture = JSON.parse(fs.readFileSync(filePath, 'utf8')) as GoldenFixture;
+      assert.ok(fixture.name, `${entry}: fixture is missing "name"`);
+      assert.equal(
+        `${fixture.name}.json`,
+        entry,
+        `${entry}: fixture "name" must match its file name`,
+      );
+      return fixture;
+    });
+}
+
+const fixtures = loadFixtures();
+
+// Fixtures are not copied into dist by tsc; the corpus only runs from src.
+test('golden corpus has fixtures', { skip: !fs.existsSync(FIXTURE_DIR) }, () => {
+  assert.ok(
+    fixtures.length > 0,
+    `no golden fixtures found in ${FIXTURE_DIR}; record one with record-tokenizer-fixture:electron`,
+  );
+});
+
+for (const fixture of fixtures) {
+  const label = fixture.issueRefs?.length
+    ? `${fixture.name} (${fixture.issueRefs.join(', ')})`
+    : fixture.name;
+  test(`golden: ${label}`, async () => {
+    const deps = createReplayTokenizerDeps(fixture);
+    const subtitleData = await tokenizeSubtitle(fixture.input.text, deps);
+    assert.deepEqual(
+      projectGoldenTokens(subtitleData.tokens),
+      fixture.expected.tokens,
+      fixture.description
+        ? `${fixture.name}: ${fixture.description}`
+        : `${fixture.name}: annotated tokens diverged from recorded expectation`,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a golden-file regression corpus for the tokenizer/annotation pipeline; fixtures replay recorded Yomitan backend responses and MeCab tokens through the real `tokenizeSubtitle` pipeline in bun tests, with no Electron or live dictionaries required at test time.
- Seeds 11 fixtures covering regression classes from issues #147–#156: grammar-helper suppression, lexical くれる, kanji 非自立 nouns, N+1 targeting, reading collisions, unparsed runs, elongation, ordinal/honorific prefixes, and JLPT annotation.
- Adds `record-tokenizer-fixture:electron` script to capture new fixtures from a live Yomitan/MeCab session, with flags for known words, JLPT levels, frequency ranks, and annotation toggles.
- Adds `compare-yomitan-api:electron` script to diff SubMiner tokenization against a stock Yomitan instance via the yomitan-api bridge, isolating real segmentation and headword divergence.
- Excludes golden JSON fixtures from Prettier formatting to keep diffs clean.

## Testing

- `bun test src/core/services/tokenizer/golden-corpus.test.ts` — all 11 fixtures replay and match their recorded expected tokens.
- `bun test src/anki-integration/known-word-cache.test.ts` — existing test adjusted for `allowReadingOnlyMatch` fix; passes.
- `bun run record-tokenizer-fixture:electron` — manual spot-check: records a new fixture from a live session and prints expected tokens for review.
- `bun run compare-yomitan-api:electron` — manual spot-check against a running yomitan-api bridge; exits 0 when all fixture sentences match stock Yomitan segmentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI tooling to record tokenizer “golden” fixtures and to compare tokenizer output against the stock Yomitan API via Electron.
* **Tests**
  * Added an end-to-end golden-corpus regression suite that replays fixtures and verifies tokenization results (readings, segmentation, frequency, JLPT data).
  * Expanded Yomitan API request handling coverage for timeouts and cancellations.
* **Documentation**
  * Added documentation for recording, replaying, and troubleshooting tokenizer golden fixtures and comparisons.
* **Chores**
  * Updated formatting ignores for tokenizer fixture artifacts.
* **Tests**
  * Added/updated multiple tokenizer golden fixtures for additional regression scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->