### PR TITLE
refactor(config): dedup word card kind enum values

### DIFF
--- a/src/config/definitions/options-integrations.ts
+++ b/src/config/definitions/options-integrations.ts
@@ -1,4 +1,5 @@
 import { ResolvedConfig } from '../../types/config';
+import { WORD_CARD_KINDS } from '../../anki-integration/card-kinds';
 import { MPV_LAUNCH_MODE_VALUES } from '../../shared/mpv-launch-mode';
 import {
   NOTIFICATION_TYPE_VALUES,
@@ -377,7 +378,7 @@ export function buildIntegrationConfigOptionRegistry(
     {
       path: 'ankiConnect.lapisKiku.wordCardKind',
       kind: 'enum',
-      enumValues: ['word-and-sentence', 'click', 'sentence', 'audio', 'none'],
+      enumValues: WORD_CARD_KINDS,
       enumLabels: {
         'word-and-sentence': 'Word and sentence card (IsWordAndSentenceCard)',
         click: 'Click card (IsClickCard)',


### PR DESCRIPTION
## Summary

Replaces the hardcoded `wordCardKind` enum value list in `options-integrations.ts` with the shared `WORD_CARD_KINDS` constant from `card-kinds`, removing a duplicated source of truth for the Lapis/Kiku word card kind options.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / internal
- [ ] Documentation
- [ ] Other

## Related issues

Follow-up to configurable word card type work on `configure-card-type`. Delete if none.

## How was this tested?

`bun run typecheck && bun run test:fast && bun run test:env && bun run build && bun run test:smoke:dist`

## Checklist

- [ ] Reconciled current-outcome changelog fragment(s), or this PR is labeled `skip-changelog` (see [`changes/README.md`](../changes/README.md))
- [ ] Docs updated in the same PR if behavior, defaults, flags, shortcuts, ports, or APIs changed
- [ ] Relevant checks pass locally (typecheck, tests, build)