### PR TITLE
fix(dictionary): stop large character dictionaries from timing out

### DIFF
--- a/changes/character-dictionary-large-imports.md
+++ b/changes/character-dictionary-large-imports.md
@@ -1,0 +1,7 @@
+type: fixed
+area: character dictionary
+
+- A large character dictionary no longer fails to install. The Yomitan import (and the delete that precedes it) used a flat 7 second budget, so a series like One Piece failed with `importYomitanDictionary(merged.zip) timed out after 7000ms` while the import was still healthy. The budget is now sized from the merged ZIP (2 minutes plus 6 seconds per MB, capped at 30 minutes); the quick queries keep the 7 second budget.
+- The "Generating character dictionary" notification now reports what it is doing instead of one static message for the whole run: the AniList page and character count while characters download (`page 12, 587 characters`), then `image 240/1220, ~4m left` per downloaded character/voice actor image, then `name 800/1220` for MeCab name splits and `saving snapshot` at the end. Updates are throttled to one per second, and every stage change and final item always reports.
+- Every long phase also carries an elapsed clock (`· 1m 35s`), refreshed every 5 seconds even when nothing else moves, so a stalled step is visibly different from a frozen app. Long imports tick the same way.
+- Image downloads are also logged every 100 files, and the import logs the timeout it computed.

--- a/src/core/utils/notification.ts
+++ b/src/core/utils/notification.ts
@@ -52,9 +52,15 @@ function resolveRuntimeDefaultNotificationIconPath(): string | null {
   });
 }
 
+/**
+ * Live notifications keyed by `replaceId`. Electron exposes no native "replace this notification"
+ * flag, so a repeated status closes its predecessor instead of stacking a fresh toast per update.
+ */
+const notificationsByReplaceId = new Map<string, Electron.Notification>();
+
 export function showDesktopNotification(
   title: string,
-  options: { body?: string; icon?: string },
+  options: { body?: string; icon?: string; replaceId?: string },
 ): void {
   const notificationOptions: {
     title: string;
@@ -98,5 +104,15 @@ export function showDesktopNotification(
   }
 
   const notification = new Notification(notificationOptions);
+  const replaceId = options.replaceId?.trim();
+  if (replaceId) {
+    notificationsByReplaceId.get(replaceId)?.close();
+    notificationsByReplaceId.set(replaceId, notification);
+    notification.once('close', () => {
+      if (notificationsByReplaceId.get(replaceId) === notification) {
+        notificationsByReplaceId.delete(replaceId);
+      }
+    });
+  }
   notification.show();
 }

--- a/src/main/character-dictionary-runtime.test.ts
+++ b/src/main/character-dictionary-runtime.test.ts
@@ -1903,7 +1903,7 @@ test('generateForCurrentMedia logs progress while resolving and rebuilding snaps
       '[dictionary] current anime guess: The Eminence in Shadow (episode 5)',
       '[dictionary] AniList match: The Eminence in Shadow -> AniList 130298',
       '[dictionary] snapshot miss for AniList 130298, fetching characters',
-      '[dictionary] downloaded AniList character page 1 for AniList 130298',
+      '[dictionary] downloaded AniList character page 1 for AniList 130298 (1 characters)',
       '[dictionary] downloading 1 images for AniList 130298',
       '[dictionary] stored snapshot for AniList 130298: 16 terms',
       '[dictionary] building ZIP for AniList 130298',

--- a/src/main/character-dictionary-runtime.ts
+++ b/src/main/character-dictionary-runtime.ts
@@ -64,6 +64,7 @@ export type {
   CharacterDictionarySnapshotProgress,
   CharacterDictionarySnapshotProgressCallbacks,
   CharacterDictionarySnapshotResult,
+  CharacterDictionarySnapshotStageProgress,
   MergedCharacterDictionaryBuildResult,
 } from './character-dictionary-runtime/types';
 
@@ -363,19 +364,28 @@ export function createCharacterDictionaryRuntimeService(deps: CharacterDictionar
       deps.logInfo?.(`[dictionary] snapshot stale for AniList ${mediaId}: ${refreshReason}`);
     }
 
+    const progressMediaTitle = mediaTitleHint || `AniList ${mediaId}`;
     progress?.onGenerating?.({
       mediaId,
-      mediaTitle: mediaTitleHint || `AniList ${mediaId}`,
+      mediaTitle: progressMediaTitle,
     });
     deps.logInfo?.(`[dictionary] snapshot miss for AniList ${mediaId}, fetching characters`);
 
     const { mediaTitle: fetchedMediaTitle, characters } = await fetchCharactersForMedia(
       mediaId,
       beforeRequest,
-      (page) => {
+      (page, charactersSoFar) => {
         deps.logInfo?.(
-          `[dictionary] downloaded AniList character page ${page} for AniList ${mediaId}`,
+          `[dictionary] downloaded AniList character page ${page} for AniList ${mediaId} (${charactersSoFar} characters)`,
         );
+        progress?.onGenerateProgress?.({
+          mediaId,
+          mediaTitle: progressMediaTitle,
+          stage: 'characters',
+          completed: charactersSoFar,
+          total: null,
+          page,
+        });
       },
     );
     if (characters.length === 0) {
@@ -403,12 +413,26 @@ export function createCharacterDictionaryRuntimeService(deps: CharacterDictionar
       );
     }
     let hasAttemptedImageDownload = false;
+    let attemptedImageCount = 0;
     for (const entry of allImageUrls) {
       if (hasAttemptedImageDownload) {
         await sleepMs(CHARACTER_IMAGE_DOWNLOAD_DELAY_MS);
       }
       hasAttemptedImageDownload = true;
       const image = await downloadCharacterImage(entry.url, entry.id);
+      attemptedImageCount += 1;
+      progress?.onGenerateProgress?.({
+        mediaId,
+        mediaTitle: progressMediaTitle,
+        stage: 'images',
+        completed: attemptedImageCount,
+        total: allImageUrls.length,
+      });
+      if (attemptedImageCount % 100 === 0) {
+        deps.logInfo?.(
+          `[dictionary] downloaded ${attemptedImageCount}/${allImageUrls.length} images for AniList ${mediaId}`,
+        );
+      }
       if (!image) continue;
       if (entry.kind === 'character') {
         imagesByCharacterId.set(entry.id, {
@@ -425,11 +449,31 @@ export function createCharacterDictionaryRuntimeService(deps: CharacterDictionar
 
     const nameSplitTokenizerAvailable = isNameSplitTokenizerAvailable();
     const resolvedNameSplits = nameSplitTokenizerAvailable
-      ? await resolveJapaneseNameSplits(characters, deps.tokenizeJapaneseName!, deps.logWarn)
+      ? await resolveJapaneseNameSplits(
+          characters,
+          deps.tokenizeJapaneseName!,
+          deps.logWarn,
+          (completed, total) => {
+            progress?.onGenerateProgress?.({
+              mediaId,
+              mediaTitle: progressMediaTitle,
+              stage: 'names',
+              completed,
+              total,
+            });
+          },
+        )
       : undefined;
     const nameSplitSource =
       resolvedNameSplits && resolvedNameSplits.size > 0 ? 'mecab' : 'heuristic';
 
+    progress?.onGenerateProgress?.({
+      mediaId,
+      mediaTitle: progressMediaTitle,
+      stage: 'saving',
+      completed: 0,
+      total: null,
+    });
     const snapshot = buildSnapshotFromCharacters(
       mediaId,
       fetchedMediaTitle || mediaTitleHint || `AniList ${mediaId}`,

--- a/src/main/character-dictionary-runtime/fetch.ts
+++ b/src/main/character-dictionary-runtime/fetch.ts
@@ -278,7 +278,7 @@ export async function fetchAniListMediaCandidateById(
 export async function fetchCharactersForMedia(
   mediaId: number,
   beforeRequest?: () => Promise<void>,
-  onPageFetched?: (page: number) => void,
+  onPageFetched?: (page: number, charactersSoFar: number) => void,
 ): Promise<{
   mediaTitle: string;
   characters: CharacterRecord[];
@@ -345,7 +345,6 @@ export async function fetchCharactersForMedia(
       },
       beforeRequest,
     );
-    onPageFetched?.(page);
 
     const media = data.Media;
     if (!media) {
@@ -414,6 +413,8 @@ export async function fetchCharactersForMedia(
         voiceActors,
       });
     }
+
+    onPageFetched?.(page, characters.length);
 
     const hasNextPage = Boolean(media.characters?.pageInfo?.hasNextPage);
     if (!hasNextPage) {

--- a/src/main/character-dictionary-runtime/name-split-resolver.ts
+++ b/src/main/character-dictionary-runtime/name-split-resolver.ts
@@ -86,8 +86,10 @@ export async function resolveJapaneseNameSplits(
   characters: CharacterRecord[],
   tokenize: NameSplitTokenizer,
   logWarn?: (message: string) => void,
+  onCharacterResolved?: (completed: number, total: number) => void,
 ): Promise<Map<string, ResolvedNameSplit>> {
   const splits = new Map<string, ResolvedNameSplit>();
+  let resolvedCharacters = 0;
   for (const character of characters) {
     const familyHintReading = buildReadingFromHint(character.lastNameHint?.trim() || '');
     const givenHintReading = buildReadingFromHint(character.firstNameHint?.trim() || '');
@@ -113,6 +115,8 @@ export async function resolveJapaneseNameSplits(
         splits.set(name, { family, given });
       }
     }
+    resolvedCharacters += 1;
+    onCharacterResolved?.(resolvedCharacters, characters.length);
   }
   return splits;
 }

--- a/src/main/character-dictionary-runtime/types.ts
+++ b/src/main/character-dictionary-runtime/types.ts
@@ -122,9 +122,24 @@ export type CharacterDictionarySnapshotProgress = {
   mediaTitle: string;
 };
 
+export type CharacterDictionarySnapshotStage = 'characters' | 'images' | 'names' | 'saving';
+
+/**
+ * Fine-grained generation progress. `total` is null while the work size is still unknown (AniList
+ * paginates characters, so the character count only settles on the last page).
+ */
+export type CharacterDictionarySnapshotStageProgress = CharacterDictionarySnapshotProgress & {
+  stage: CharacterDictionarySnapshotStage;
+  completed: number;
+  total: number | null;
+  /** AniList page currently being downloaded; only set during the `characters` stage. */
+  page?: number;
+};
+
 export type CharacterDictionarySnapshotProgressCallbacks = {
   onChecking?: (progress: CharacterDictionarySnapshotProgress) => void;
   onGenerating?: (progress: CharacterDictionarySnapshotProgress) => void;
+  onGenerateProgress?: (progress: CharacterDictionarySnapshotStageProgress) => void;
 };
 
 export type MergedCharacterDictionaryBuildResult = {

--- a/src/main/character-dictionary-runtime/zip.test.ts
+++ b/src/main/character-dictionary-runtime/zip.test.ts
@@ -143,6 +143,21 @@ test('readDictionaryZipRevision reads the built revision and rejects foreign arc
       assert.equal(readDictionaryZipRevision(cutPath), null, `cut of ${missingBytes} bytes`);
     }
 
+    // Same size, corrupt directory: a record overwritten in place has to be rejected too.
+    const centralStart = archive.readUInt32LE(archive.length - 22 + 16);
+    const brokenSignaturePath = path.join(dir, 'broken-signature.zip');
+    const brokenSignature = Buffer.from(archive);
+    brokenSignature.writeUInt32LE(0xdeadbeef, centralStart);
+    fs.writeFileSync(brokenSignaturePath, brokenSignature);
+    assert.equal(readDictionaryZipRevision(brokenSignaturePath), null);
+
+    const brokenLengthPath = path.join(dir, 'broken-length.zip');
+    const brokenLength = Buffer.from(archive);
+    // Name length that runs the walk past the end of the directory.
+    brokenLength.writeUInt16LE(0xffff, centralStart + 28);
+    fs.writeFileSync(brokenLengthPath, brokenLength);
+    assert.equal(readDictionaryZipRevision(brokenLengthPath), null);
+
     const foreignPath = path.join(dir, 'foreign.zip');
     fs.writeFileSync(foreignPath, Buffer.from('not a zip at all', 'utf8'));
     assert.equal(readDictionaryZipRevision(foreignPath), null);

--- a/src/main/character-dictionary-runtime/zip.test.ts
+++ b/src/main/character-dictionary-runtime/zip.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { buildDictionaryZip } from './zip';
+import { buildDictionaryZip, readDictionaryZipRevision } from './zip';
 import type { CharacterDictionaryTermEntry } from './types';
 
 function makeTempDir(): string {
@@ -103,5 +103,40 @@ test('buildDictionaryZip writes a valid stored zip without fs.writeFileSync', ()
     fs.writeFileSync = originalWriteFileSync;
     Buffer.concat = originalBufferConcat;
     cleanupDir(tempDir);
+  }
+});
+
+test('readDictionaryZipRevision reads the built revision and rejects foreign archives', () => {
+  const dir = makeTempDir();
+  try {
+    const zipPath = path.join(dir, 'merged.zip');
+    buildDictionaryZip(
+      zipPath,
+      'SubMiner Character Dictionary',
+      'Character names',
+      'rev-42',
+      [
+        {
+          term: 'ルフィ',
+          reading: 'ルフィ',
+          role: 'main',
+          glossary: [],
+        } as unknown as CharacterDictionaryTermEntry,
+      ],
+      [],
+    );
+
+    assert.equal(readDictionaryZipRevision(zipPath), 'rev-42');
+    assert.equal(readDictionaryZipRevision(path.join(dir, 'missing.zip')), null);
+
+    const truncatedPath = path.join(dir, 'truncated.zip');
+    fs.writeFileSync(truncatedPath, fs.readFileSync(zipPath).subarray(0, 40));
+    assert.equal(readDictionaryZipRevision(truncatedPath), null);
+
+    const foreignPath = path.join(dir, 'foreign.zip');
+    fs.writeFileSync(foreignPath, Buffer.from('not a zip at all', 'utf8'));
+    assert.equal(readDictionaryZipRevision(foreignPath), null);
+  } finally {
+    cleanupDir(dir);
   }
 });

--- a/src/main/character-dictionary-runtime/zip.test.ts
+++ b/src/main/character-dictionary-runtime/zip.test.ts
@@ -129,9 +129,19 @@ test('readDictionaryZipRevision reads the built revision and rejects foreign arc
     assert.equal(readDictionaryZipRevision(zipPath), 'rev-42');
     assert.equal(readDictionaryZipRevision(path.join(dir, 'missing.zip')), null);
 
+    const archive = fs.readFileSync(zipPath);
     const truncatedPath = path.join(dir, 'truncated.zip');
-    fs.writeFileSync(truncatedPath, fs.readFileSync(zipPath).subarray(0, 40));
+    fs.writeFileSync(truncatedPath, archive.subarray(0, 40));
     assert.equal(readDictionaryZipRevision(truncatedPath), null);
+
+    // An archive cut short after index.json still holds a readable revision, but importing it
+    // would hand Yomitan a half-written file: the missing end-of-central-directory record has to
+    // reject it. One byte off the end is enough to make the record incomplete.
+    for (const missingBytes of [1, 22, archive.length - 200]) {
+      const cutPath = path.join(dir, `cut-${missingBytes}.zip`);
+      fs.writeFileSync(cutPath, archive.subarray(0, archive.length - missingBytes));
+      assert.equal(readDictionaryZipRevision(cutPath), null, `cut of ${missingBytes} bytes`);
+    }
 
     const foreignPath = path.join(dir, 'foreign.zip');
     fs.writeFileSync(foreignPath, Buffer.from('not a zip at all', 'utf8'));

--- a/src/main/character-dictionary-runtime/zip.ts
+++ b/src/main/character-dictionary-runtime/zip.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { writeStoredZip } from '../../shared/stored-zip';
+import { readStoredZipFirstFile, writeStoredZip } from '../../shared/stored-zip';
 import { ensureDir } from './fs-utils';
 import type { CharacterDictionarySnapshotImage, CharacterDictionaryTermEntry } from './types';
 
@@ -29,6 +29,23 @@ function createTagBank(): Array<[string, string, number, string, number]> {
     ['side', 'name', 0, 'Side character', 0],
     ['appears', 'name', 0, 'Minor appearance', 0],
   ];
+}
+
+/**
+ * Revision recorded inside a built dictionary ZIP, or null when the archive is missing, truncated,
+ * or not one of ours. `index.json` is always the first entry written by {@link buildDictionaryZip}.
+ */
+export function readDictionaryZipRevision(zipPath: string): string | null {
+  const firstFile = readStoredZipFirstFile(zipPath);
+  if (!firstFile || firstFile.name !== 'index.json') {
+    return null;
+  }
+  try {
+    const index = JSON.parse(firstFile.data.toString('utf8')) as { revision?: unknown };
+    return typeof index.revision === 'string' && index.revision.length > 0 ? index.revision : null;
+  } catch {
+    return null;
+  }
 }
 
 export function buildDictionaryZip(

--- a/src/main/runtime/character-dictionary-auto-sync-messages.ts
+++ b/src/main/runtime/character-dictionary-auto-sync-messages.ts
@@ -1,0 +1,90 @@
+import type { CharacterDictionarySnapshotStageProgress } from '../character-dictionary-runtime';
+
+export function buildSyncingMessage(mediaTitle: string): string {
+  return `Updating character dictionary for ${mediaTitle}...`;
+}
+
+export function buildCheckingMessage(mediaTitle: string): string {
+  return `Checking character dictionary for ${mediaTitle}...`;
+}
+
+export function buildGeneratingMessage(mediaTitle: string, detail?: string): string {
+  return detail
+    ? `Generating character dictionary for ${mediaTitle} (${detail})...`
+    : `Generating character dictionary for ${mediaTitle}...`;
+}
+
+export function formatCharacterDictionaryProgressDetail(
+  progress: CharacterDictionarySnapshotStageProgress,
+  remainingMs: number | null,
+): string {
+  if (progress.stage === 'saving') {
+    return 'saving snapshot';
+  }
+  if (progress.stage === 'names') {
+    return progress.total !== null && progress.total > 0
+      ? `name ${progress.completed}/${progress.total}`
+      : `${progress.completed} names`;
+  }
+  if (progress.stage === 'images') {
+    const counted =
+      progress.total !== null && progress.total > 0
+        ? `image ${progress.completed}/${progress.total}`
+        : `${progress.completed} images`;
+    return remainingMs !== null
+      ? `${counted}, ~${formatRemainingDuration(remainingMs)} left`
+      : counted;
+  }
+  const page = typeof progress.page === 'number' ? `page ${progress.page}, ` : '';
+  return `${page}${progress.completed} characters`;
+}
+
+export function formatElapsedDuration(elapsedMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m ${String(seconds).padStart(2, '0')}s` : `${seconds}s`;
+}
+
+/** Coarser than the elapsed clock: an estimate that ticks every second reads as precision it lacks. */
+export function formatRemainingDuration(remainingMs: number): string {
+  const totalSeconds = Math.max(1, Math.round(remainingMs / 1000));
+  if (totalSeconds >= 60) {
+    return `${Math.max(1, Math.round(totalSeconds / 60))}m`;
+  }
+  return `${Math.max(5, Math.ceil(totalSeconds / 5) * 5)}s`;
+}
+
+/**
+ * The elapsed clock is the part that proves the app is alive: a stalled network fetch freezes the
+ * counts, but the clock keeps moving.
+ */
+export function joinGeneratingDetail(detail: string | null, elapsedMs: number): string | undefined {
+  const parts = [detail, elapsedMs >= 5_000 ? formatElapsedDuration(elapsedMs) : null].filter(
+    (part): part is string => typeof part === 'string' && part.length > 0,
+  );
+  return parts.length > 0 ? parts.join(' · ') : undefined;
+}
+
+export function buildImportingMessage(mediaTitle: string, elapsedMs?: number): string {
+  const elapsed =
+    typeof elapsedMs === 'number' && elapsedMs >= 1000
+      ? ` (${formatElapsedDuration(elapsedMs)})`
+      : '';
+  return `Importing character dictionary for ${mediaTitle}${elapsed}...`;
+}
+
+export function buildBuildingMessage(mediaTitle: string): string {
+  return `Building character dictionary for ${mediaTitle}...`;
+}
+
+export function buildReadyMessage(mediaTitle: string): string {
+  return `Character dictionary ready for ${mediaTitle}`;
+}
+
+export function buildFailedMessage(mediaTitle: string | null, errorMessage: string): string {
+  if (mediaTitle) {
+    return `Character dictionary sync failed for ${mediaTitle}: ${errorMessage}`;
+  }
+  return `Character dictionary sync failed: ${errorMessage}`;
+}

--- a/src/main/runtime/character-dictionary-auto-sync-notifications.test.ts
+++ b/src/main/runtime/character-dictionary-auto-sync-notifications.test.ts
@@ -214,3 +214,69 @@ test('auto sync notifications let startup sequencer own osd-system desktop deliv
 
   assert.deepEqual(calls, ['osd:importing', 'desktop:SubMiner:importing']);
 });
+
+test('auto sync desktop notifications reuse one replace id across every phase', () => {
+  const replaceIds: Array<string | undefined> = [];
+  const deps = {
+    getNotificationType: () => 'system' as const,
+    showOsd: () => undefined,
+    showDesktopNotification: (_title: string, options: { body?: string; replaceId?: string }) => {
+      replaceIds.push(options.replaceId);
+    },
+  };
+
+  for (const phase of ['checking', 'generating', 'importing', 'ready'] as const) {
+    notifyCharacterDictionaryAutoSyncStatus(makeEvent(phase, phase), deps);
+  }
+
+  assert.deepEqual(replaceIds, [
+    'character-dictionary-auto-sync',
+    'character-dictionary-auto-sync',
+    'character-dictionary-auto-sync',
+    'character-dictionary-auto-sync',
+  ]);
+});
+
+test('overlay-unavailable desktop fallback shares the same replace id', () => {
+  const replaceIds: Array<string | undefined> = [];
+
+  notifyCharacterDictionaryAutoSyncStatus(makeEvent('generating', 'generating'), {
+    getNotificationType: () => 'overlay',
+    showOsd: () => undefined,
+    showDesktopNotification: (_title, options) => {
+      replaceIds.push(options.replaceId);
+    },
+  });
+
+  assert.deepEqual(replaceIds, ['character-dictionary-auto-sync']);
+});
+
+test('startup lanes keep one desktop notification per lane', () => {
+  const calls: Array<{ body?: string; replaceId?: string }> = [];
+  const sequencer = createStartupOsdSequencer({
+    getNotificationType: () => 'system',
+    showOsd: () => undefined,
+    showDesktopNotification: (_title, options) => {
+      calls.push(options);
+    },
+  });
+
+  sequencer.markTokenizationReady();
+  notifyCharacterDictionaryAutoSyncStatus(makeEvent('generating', 'generating one'), {
+    getNotificationType: () => 'osd',
+    showOsd: () => undefined,
+    showDesktopNotification: () => undefined,
+    startupOsdSequencer: sequencer,
+  });
+  notifyCharacterDictionaryAutoSyncStatus(makeEvent('generating', 'generating two'), {
+    getNotificationType: () => 'osd',
+    showOsd: () => undefined,
+    showDesktopNotification: () => undefined,
+    startupOsdSequencer: sequencer,
+  });
+
+  assert.deepEqual(
+    calls.map((call) => call.replaceId),
+    ['startup-status', 'startup-status'],
+  );
+});

--- a/src/main/runtime/character-dictionary-auto-sync-notifications.ts
+++ b/src/main/runtime/character-dictionary-auto-sync-notifications.ts
@@ -9,13 +9,17 @@ export interface CharacterDictionaryAutoSyncNotificationDeps {
   getNotificationType: () => NotificationType | undefined;
   showOsd: (message: string) => boolean | void;
   showOverlayNotification?: (payload: OverlayNotificationPayload) => void;
-  showDesktopNotification: (title: string, options: { body?: string }) => void;
+  showDesktopNotification: (title: string, options: { body?: string; replaceId?: string }) => void;
   startupOsdSequencer?: {
     notifyCharacterDictionaryStatus: (
       event: StartupOsdSequencerCharacterDictionaryEvent,
     ) => boolean;
   };
 }
+
+// One live desktop notification for the whole sync: progress updates replace each other and the
+// terminal ready/failed message replaces the last progress one, matching the overlay toast.
+const CHARACTER_DICTIONARY_DESKTOP_NOTIFICATION_ID = 'character-dictionary-auto-sync';
 
 function isTerminalPhase(phase: CharacterDictionaryAutoSyncNotificationEvent['phase']): boolean {
   return phase === 'ready' || phase === 'failed';
@@ -53,7 +57,10 @@ export function notifyCharacterDictionaryAutoSyncStatus(
         persistent: !isTerminalPhase(event.phase),
       });
     } else if (!shouldShowDesktop(type)) {
-      deps.showDesktopNotification('SubMiner', { body: event.message });
+      deps.showDesktopNotification('SubMiner', {
+        body: event.message,
+        replaceId: CHARACTER_DICTIONARY_DESKTOP_NOTIFICATION_ID,
+      });
     }
   }
 
@@ -69,6 +76,9 @@ export function notifyCharacterDictionaryAutoSyncStatus(
   }
 
   if (shouldShowDesktop(type) && !startupSequencerShown) {
-    deps.showDesktopNotification('SubMiner', { body: event.message });
+    deps.showDesktopNotification('SubMiner', {
+      body: event.message,
+      replaceId: CHARACTER_DICTIONARY_DESKTOP_NOTIFICATION_ID,
+    });
   }
 }

--- a/src/main/runtime/character-dictionary-auto-sync.test.ts
+++ b/src/main/runtime/character-dictionary-auto-sync.test.ts
@@ -14,6 +14,14 @@ function makeTempDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'subminer-char-dict-auto-sync-'));
 }
 
+async function waitUntil(predicate: () => boolean, label: string): Promise<void> {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
 function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((nextResolve) => {
@@ -187,7 +195,7 @@ test('auto sync imports merged dictionary and persists MRU state', async () => {
     '[dictionary:auto-sync] syncing current anime snapshot',
     '[dictionary:auto-sync] active AniList media set: 130298 - The Eminence in Shadow',
     '[dictionary:auto-sync] rebuilding merged dictionary for active anime set',
-    '[dictionary:auto-sync] importing merged dictionary: /tmp/subminer-character-dictionary.zip',
+    '[dictionary:auto-sync] importing merged dictionary: /tmp/subminer-character-dictionary.zip (timeout 120000ms)',
     '[dictionary:auto-sync] applying Yomitan settings for SubMiner Character Dictionary',
     '[dictionary:auto-sync] synced AniList 130298: SubMiner Character Dictionary (2544 entries)',
   ]);
@@ -958,11 +966,9 @@ test('auto sync emits building while merged dictionary generation is in flight',
   });
 
   const syncPromise = runtime.runSyncNow();
-  await Promise.resolve();
-
-  assert.equal(
-    events.some((event) => event.phase === 'building'),
-    true,
+  await waitUntil(
+    () => events.some((event) => event.phase === 'building'),
+    'the building status event',
   );
 
   buildDeferred.resolve({
@@ -1029,8 +1035,7 @@ test('auto sync waits for tokenization-ready gate before Yomitan mutations', asy
   });
 
   const syncPromise = runtime.runSyncNow();
-  await Promise.resolve();
-  await Promise.resolve();
+  await waitUntil(() => calls.includes('wait'), 'the tokenization-ready gate');
 
   assert.deepEqual(calls, ['build', 'wait']);
 
@@ -1038,4 +1043,333 @@ test('auto sync waits for tokenization-ready gate before Yomitan mutations', asy
   await syncPromise;
 
   assert.deepEqual(calls, ['build', 'wait', 'info', 'import', 'settings']);
+});
+
+test('auto sync scales the import timeout with the merged dictionary size', async () => {
+  const userDataPath = makeTempDir();
+  const dictionariesDir = path.join(userDataPath, 'character-dictionaries');
+  fs.mkdirSync(dictionariesDir, { recursive: true });
+  const zipPath = path.join(dictionariesDir, 'merged.zip');
+  // 2 MB of merged dictionary buys ~12s of import budget on top of the base.
+  fs.writeFileSync(zipPath, Buffer.alloc(2 * 1024 * 1024));
+  const events: Array<{ phase: string; message: string }> = [];
+  let importedRevision: string | null = null;
+
+  const runtime = createCharacterDictionaryAutoSyncRuntimeService({
+    userDataPath,
+    getConfig: () => ({ enabled: true, maxLoaded: 3, profileScope: 'all' }),
+    getOrCreateCurrentSnapshot: async () => ({
+      mediaId: 21,
+      mediaTitle: 'ONE PIECE',
+      entryCount: 4000,
+      fromCache: false,
+      updatedAt: 1000,
+    }),
+    buildMergedDictionary: async () => ({
+      zipPath,
+      revision: 'rev-21',
+      dictionaryTitle: 'SubMiner Character Dictionary',
+      entryCount: 4000,
+    }),
+    getYomitanDictionaryInfo: async () =>
+      importedRevision
+        ? [{ title: 'SubMiner Character Dictionary', revision: importedRevision }]
+        : [],
+    importYomitanDictionary: async () => {
+      // Far longer than the quick-operation budget, well inside the size-scaled one.
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      importedRevision = 'rev-21';
+      return true;
+    },
+    deleteYomitanDictionary: async () => true,
+    upsertYomitanDictionarySettings: async () => true,
+    now: () => 1000,
+    operationTimeoutMs: 5,
+    dictionaryImportTimeoutBaseMs: 20,
+    onSyncStatus: (event) => {
+      events.push({ phase: event.phase, message: event.message });
+    },
+  });
+
+  await runtime.runSyncNow();
+
+  assert.equal(
+    events.some((event) => event.phase === 'failed'),
+    false,
+  );
+  assert.deepEqual(events.at(-1), {
+    phase: 'ready',
+    message: 'Character dictionary ready for ONE PIECE',
+  });
+});
+
+test('auto sync reports the scaled budget when an import really does hang', async () => {
+  const userDataPath = makeTempDir();
+  const events: Array<{ phase: string; message: string }> = [];
+
+  const runtime = createCharacterDictionaryAutoSyncRuntimeService({
+    userDataPath,
+    getConfig: () => ({ enabled: true, maxLoaded: 3, profileScope: 'all' }),
+    getOrCreateCurrentSnapshot: async () => ({
+      mediaId: 21,
+      mediaTitle: 'ONE PIECE',
+      entryCount: 4000,
+      fromCache: false,
+      updatedAt: 1000,
+    }),
+    buildMergedDictionary: async () => ({
+      zipPath: path.join(userDataPath, 'character-dictionaries', 'missing.zip'),
+      revision: 'rev-21',
+      dictionaryTitle: 'SubMiner Character Dictionary',
+      entryCount: 4000,
+    }),
+    getYomitanDictionaryInfo: async () => [],
+    importYomitanDictionary: () => new Promise<boolean>(() => {}),
+    deleteYomitanDictionary: async () => true,
+    upsertYomitanDictionarySettings: async () => true,
+    now: () => 1000,
+    dictionaryImportTimeoutBaseMs: 20,
+    onSyncStatus: (event) => {
+      events.push({ phase: event.phase, message: event.message });
+    },
+  });
+
+  await assert.rejects(
+    runtime.runSyncNow(),
+    /importYomitanDictionary\(missing\.zip\) timed out after 20ms/,
+  );
+  assert.equal(events.at(-1)?.phase, 'failed');
+});
+
+test('auto sync ticks the importing notification while the import runs', async () => {
+  const userDataPath = makeTempDir();
+  const events: Array<{ phase: string; message: string }> = [];
+  const scheduled: Array<() => void> = [];
+  const importDeferred = createDeferred<boolean>();
+  let clock = 1000;
+
+  const runtime = createCharacterDictionaryAutoSyncRuntimeService({
+    userDataPath,
+    getConfig: () => ({ enabled: true, maxLoaded: 3, profileScope: 'all' }),
+    getOrCreateCurrentSnapshot: async () => ({
+      mediaId: 21,
+      mediaTitle: 'ONE PIECE',
+      entryCount: 4000,
+      fromCache: false,
+      updatedAt: 1000,
+    }),
+    buildMergedDictionary: async () => ({
+      zipPath: '/tmp/merged.zip',
+      revision: 'rev-21',
+      dictionaryTitle: 'SubMiner Character Dictionary',
+      entryCount: 4000,
+    }),
+    getYomitanDictionaryInfo: async () => [],
+    importYomitanDictionary: () => importDeferred.promise,
+    deleteYomitanDictionary: async () => true,
+    upsertYomitanDictionarySettings: async () => true,
+    now: () => clock,
+    schedule: (fn) => {
+      scheduled.push(fn);
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearSchedule: () => undefined,
+    onSyncStatus: (event) => {
+      events.push({ phase: event.phase, message: event.message });
+    },
+  });
+
+  const syncPromise = runtime.runSyncNow();
+  await waitUntil(
+    () => events.some((event) => event.phase === 'importing'),
+    'the importing status event',
+  );
+
+  clock = 1000 + 65_000;
+  // The importing heartbeat is the most recently scheduled tick.
+  scheduled.at(-1)!();
+
+  assert.deepEqual(events.at(-1), {
+    phase: 'importing',
+    message: 'Importing character dictionary for ONE PIECE (1m 05s)...',
+  });
+
+  importDeferred.resolve(true);
+  await syncPromise;
+  assert.equal(events.at(-1)?.phase, 'ready');
+});
+
+test('auto sync reports character and image counts while generating a snapshot', async () => {
+  const userDataPath = makeTempDir();
+  const events: Array<{ phase: string; message: string }> = [];
+  let clock = 1000;
+  let importedRevision: string | null = null;
+
+  const runtime = createCharacterDictionaryAutoSyncRuntimeService({
+    userDataPath,
+    getConfig: () => ({ enabled: true, maxLoaded: 3, profileScope: 'all' }),
+    getOrCreateCurrentSnapshot: async (_targetPath, progress) => {
+      progress?.onGenerating?.({ mediaId: 21, mediaTitle: 'ONE PIECE' });
+      progress?.onGenerateProgress?.({
+        mediaId: 21,
+        mediaTitle: 'ONE PIECE',
+        stage: 'characters',
+        completed: 50,
+        total: null,
+        page: 12,
+      });
+      // Same stage, same clock tick: throttled away so a 33-page fetch cannot spam the overlay.
+      progress?.onGenerateProgress?.({
+        mediaId: 21,
+        mediaTitle: 'ONE PIECE',
+        stage: 'characters',
+        completed: 100,
+        total: null,
+        page: 13,
+      });
+      // A stage change always reports, throttle window or not.
+      progress?.onGenerateProgress?.({
+        mediaId: 21,
+        mediaTitle: 'ONE PIECE',
+        stage: 'images',
+        completed: 1,
+        total: 1220,
+      });
+      clock += 2000;
+      progress?.onGenerateProgress?.({
+        mediaId: 21,
+        mediaTitle: 'ONE PIECE',
+        stage: 'images',
+        completed: 240,
+        total: 1220,
+      });
+      clock += 6000;
+      progress?.onGenerateProgress?.({
+        mediaId: 21,
+        mediaTitle: 'ONE PIECE',
+        stage: 'names',
+        completed: 800,
+        total: 1220,
+      });
+      progress?.onGenerateProgress?.({
+        mediaId: 21,
+        mediaTitle: 'ONE PIECE',
+        stage: 'saving',
+        completed: 0,
+        total: null,
+      });
+      return {
+        mediaId: 21,
+        mediaTitle: 'ONE PIECE',
+        entryCount: 4000,
+        fromCache: false,
+        updatedAt: 1000,
+      };
+    },
+    buildMergedDictionary: async () => ({
+      zipPath: '/tmp/merged.zip',
+      revision: 'rev-21',
+      dictionaryTitle: 'SubMiner Character Dictionary',
+      entryCount: 4000,
+    }),
+    getYomitanDictionaryInfo: async () =>
+      importedRevision
+        ? [{ title: 'SubMiner Character Dictionary', revision: importedRevision }]
+        : [],
+    importYomitanDictionary: async () => {
+      importedRevision = 'rev-21';
+      return true;
+    },
+    deleteYomitanDictionary: async () => true,
+    upsertYomitanDictionarySettings: async () => true,
+    now: () => clock,
+    onSyncStatus: (event) => {
+      events.push({ phase: event.phase, message: event.message });
+    },
+  });
+
+  await runtime.runSyncNow();
+
+  assert.deepEqual(
+    events.filter((event) => event.phase === 'generating').map((event) => event.message),
+    [
+      'Generating character dictionary for ONE PIECE...',
+      'Generating character dictionary for ONE PIECE (page 12, 50 characters)...',
+      'Generating character dictionary for ONE PIECE (image 1/1220)...',
+      'Generating character dictionary for ONE PIECE (image 240/1220, ~10s left)...',
+      'Generating character dictionary for ONE PIECE (name 800/1220 · 8s)...',
+      'Generating character dictionary for ONE PIECE (saving snapshot · 8s)...',
+    ],
+  );
+});
+
+test('auto sync keeps the generating clock ticking when a stage stalls', async () => {
+  const userDataPath = makeTempDir();
+  const events: Array<{ phase: string; message: string }> = [];
+  const scheduled: Array<() => void> = [];
+  const snapshotDeferred = createDeferred<{
+    mediaId: number;
+    mediaTitle: string;
+    entryCount: number;
+    fromCache: boolean;
+    updatedAt: number;
+  }>();
+  let clock = 1000;
+
+  const runtime = createCharacterDictionaryAutoSyncRuntimeService({
+    userDataPath,
+    getConfig: () => ({ enabled: true, maxLoaded: 3, profileScope: 'all' }),
+    getOrCreateCurrentSnapshot: async (_targetPath, progress) => {
+      progress?.onGenerating?.({ mediaId: 21, mediaTitle: 'ONE PIECE' });
+      progress?.onGenerateProgress?.({
+        mediaId: 21,
+        mediaTitle: 'ONE PIECE',
+        stage: 'images',
+        completed: 240,
+        total: 1220,
+      });
+      return await snapshotDeferred.promise;
+    },
+    buildMergedDictionary: async () => ({
+      zipPath: '/tmp/merged.zip',
+      revision: 'rev-21',
+      dictionaryTitle: 'SubMiner Character Dictionary',
+      entryCount: 4000,
+    }),
+    getYomitanDictionaryInfo: async () => [],
+    importYomitanDictionary: async () => true,
+    deleteYomitanDictionary: async () => true,
+    upsertYomitanDictionarySettings: async () => true,
+    now: () => clock,
+    schedule: (fn) => {
+      scheduled.push(fn);
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearSchedule: () => undefined,
+    onSyncStatus: (event) => {
+      events.push({ phase: event.phase, message: event.message });
+    },
+  });
+
+  const syncPromise = runtime.runSyncNow();
+  await waitUntil(() => scheduled.length > 0, 'the generating heartbeat');
+
+  // No further progress arrives: only the clock moves.
+  clock += 95_000;
+  scheduled.at(-1)!();
+
+  assert.deepEqual(events.at(-1), {
+    phase: 'generating',
+    message: 'Generating character dictionary for ONE PIECE (image 240/1220 · 1m 35s)...',
+  });
+
+  snapshotDeferred.resolve({
+    mediaId: 21,
+    mediaTitle: 'ONE PIECE',
+    entryCount: 4000,
+    fromCache: false,
+    updatedAt: 1000,
+  });
+  await syncPromise;
+  assert.equal(events.at(-1)?.phase, 'ready');
 });

--- a/src/main/runtime/character-dictionary-auto-sync.test.ts
+++ b/src/main/runtime/character-dictionary-auto-sync.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import test from 'node:test';
+import { buildDictionaryZip } from '../character-dictionary-runtime/zip';
 import {
   createCharacterDictionaryAutoSyncRuntimeService,
   getCharacterDictionaryManagerSnapshot,
@@ -375,7 +376,14 @@ test('auto sync reimports existing merged zip without rebuilding on unchanged re
   const userDataPath = makeTempDir();
   const dictionariesDir = path.join(userDataPath, 'character-dictionaries');
   fs.mkdirSync(dictionariesDir, { recursive: true });
-  fs.writeFileSync(path.join(dictionariesDir, 'merged.zip'), 'cached-zip', 'utf8');
+  buildDictionaryZip(
+    path.join(dictionariesDir, 'merged.zip'),
+    'SubMiner Character Dictionary',
+    'Character names',
+    'rev-7',
+    [{ term: 'フリーレン', reading: 'フリーレン', role: 'main', glossary: [] } as never],
+    [],
+  );
   const mergedBuilds: number[][] = [];
   const imports: string[] = [];
   let importedRevision: string | null = null;
@@ -1077,14 +1085,15 @@ test('auto sync scales the import timeout with the merged dictionary size', asyn
         : [],
     importYomitanDictionary: async () => {
       // Far longer than the quick-operation budget, well inside the size-scaled one.
-      await new Promise((resolve) => setTimeout(resolve, 60));
+      await new Promise((resolve) => setTimeout(resolve, 400));
       importedRevision = 'rev-21';
       return true;
     },
     deleteYomitanDictionary: async () => true,
     upsertYomitanDictionarySettings: async () => true,
     now: () => 1000,
-    operationTimeoutMs: 5,
+    // Comfortable for the stubs that resolve immediately, still far under the import's 400ms.
+    operationTimeoutMs: 100,
     dictionaryImportTimeoutBaseMs: 20,
     onSyncStatus: (event) => {
       events.push({ phase: event.phase, message: event.message });
@@ -1372,4 +1381,66 @@ test('auto sync keeps the generating clock ticking when a stage stalls', async (
   });
   await syncPromise;
   assert.equal(events.at(-1)?.phase, 'ready');
+});
+
+test('auto sync rebuilds instead of importing a cached merged ZIP with a mismatched revision', async () => {
+  const userDataPath = makeTempDir();
+  const dictionariesDir = path.join(userDataPath, 'character-dictionaries');
+  fs.mkdirSync(dictionariesDir, { recursive: true });
+  const statePath = path.join(dictionariesDir, 'auto-sync-state.json');
+  fs.writeFileSync(
+    statePath,
+    JSON.stringify({
+      activeMediaIds: ['7 - Frieren'],
+      mergedRevision: 'rev-7',
+      mergedDictionaryTitle: 'SubMiner Character Dictionary',
+    }),
+    'utf8',
+  );
+  // Left over from an interrupted run: the archive on disk is not the revision state recorded.
+  buildDictionaryZip(
+    path.join(dictionariesDir, 'merged.zip'),
+    'SubMiner Character Dictionary',
+    'Character names',
+    'rev-stale',
+    [{ term: 'フリーレン', reading: 'フリーレン', role: 'main', glossary: [] } as never],
+    [],
+  );
+  const mergedBuilds: number[][] = [];
+  const imports: string[] = [];
+
+  const runtime = createCharacterDictionaryAutoSyncRuntimeService({
+    userDataPath,
+    getConfig: () => ({ enabled: true, maxLoaded: 3, profileScope: 'all' }),
+    getOrCreateCurrentSnapshot: async () => ({
+      mediaId: 7,
+      mediaTitle: 'Frieren',
+      entryCount: 100,
+      fromCache: true,
+      updatedAt: 1000,
+    }),
+    buildMergedDictionary: async (mediaIds) => {
+      mergedBuilds.push([...mediaIds]);
+      return {
+        zipPath: '/tmp/rebuilt-merged.zip',
+        revision: 'rev-7',
+        dictionaryTitle: 'SubMiner Character Dictionary',
+        entryCount: 100,
+      };
+    },
+    // Yomitan does not have the dictionary, so the sync has to import despite the cached state.
+    getYomitanDictionaryInfo: async () => [],
+    importYomitanDictionary: async (zipPath) => {
+      imports.push(zipPath);
+      return true;
+    },
+    deleteYomitanDictionary: async () => true,
+    upsertYomitanDictionarySettings: async () => true,
+    now: () => 1000,
+  });
+
+  await runtime.runSyncNow();
+
+  assert.deepEqual(mergedBuilds, [[7]]);
+  assert.deepEqual(imports, ['/tmp/rebuilt-merged.zip']);
 });

--- a/src/main/runtime/character-dictionary-auto-sync.ts
+++ b/src/main/runtime/character-dictionary-auto-sync.ts
@@ -1,6 +1,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { ensureDir } from '../../shared/fs-utils';
+import {
+  buildBuildingMessage,
+  buildCheckingMessage,
+  buildFailedMessage,
+  buildGeneratingMessage,
+  buildImportingMessage,
+  buildReadyMessage,
+  formatCharacterDictionaryProgressDetail,
+  joinGeneratingDetail,
+} from './character-dictionary-auto-sync-messages';
+import { readDictionaryZipRevision } from '../character-dictionary-runtime/zip';
 import type { AnilistCharacterDictionaryProfileScope } from '../../types';
 import type {
   CharacterDictionarySnapshotProgressCallbacks,
@@ -358,95 +369,6 @@ function sameMembership(left: number[], right: number[]): boolean {
   return arraysEqual(leftSorted, rightSorted);
 }
 
-function buildSyncingMessage(mediaTitle: string): string {
-  return `Updating character dictionary for ${mediaTitle}...`;
-}
-
-function buildCheckingMessage(mediaTitle: string): string {
-  return `Checking character dictionary for ${mediaTitle}...`;
-}
-
-function buildGeneratingMessage(mediaTitle: string, detail?: string): string {
-  return detail
-    ? `Generating character dictionary for ${mediaTitle} (${detail})...`
-    : `Generating character dictionary for ${mediaTitle}...`;
-}
-
-function formatCharacterDictionaryProgressDetail(
-  progress: CharacterDictionarySnapshotStageProgress,
-  remainingMs: number | null,
-): string {
-  if (progress.stage === 'saving') {
-    return 'saving snapshot';
-  }
-  if (progress.stage === 'names') {
-    return progress.total !== null && progress.total > 0
-      ? `name ${progress.completed}/${progress.total}`
-      : `${progress.completed} names`;
-  }
-  if (progress.stage === 'images') {
-    const counted =
-      progress.total !== null && progress.total > 0
-        ? `image ${progress.completed}/${progress.total}`
-        : `${progress.completed} images`;
-    return remainingMs !== null
-      ? `${counted}, ~${formatRemainingDuration(remainingMs)} left`
-      : counted;
-  }
-  const page = typeof progress.page === 'number' ? `page ${progress.page}, ` : '';
-  return `${page}${progress.completed} characters`;
-}
-
-function formatElapsedDuration(elapsedMs: number): string {
-  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return minutes > 0 ? `${minutes}m ${String(seconds).padStart(2, '0')}s` : `${seconds}s`;
-}
-
-/** Coarser than the elapsed clock: an estimate that ticks every second reads as precision it lacks. */
-function formatRemainingDuration(remainingMs: number): string {
-  const totalSeconds = Math.max(1, Math.round(remainingMs / 1000));
-  if (totalSeconds >= 60) {
-    return `${Math.max(1, Math.round(totalSeconds / 60))}m`;
-  }
-  return `${Math.max(5, Math.ceil(totalSeconds / 5) * 5)}s`;
-}
-
-/**
- * The elapsed clock is the part that proves the app is alive: a stalled network fetch freezes the
- * counts, but the clock keeps moving.
- */
-function joinGeneratingDetail(detail: string | null, elapsedMs: number): string | undefined {
-  const parts = [detail, elapsedMs >= 5_000 ? formatElapsedDuration(elapsedMs) : null].filter(
-    (part): part is string => typeof part === 'string' && part.length > 0,
-  );
-  return parts.length > 0 ? parts.join(' · ') : undefined;
-}
-
-function buildImportingMessage(mediaTitle: string, elapsedMs?: number): string {
-  const elapsed =
-    typeof elapsedMs === 'number' && elapsedMs >= 1000
-      ? ` (${formatElapsedDuration(elapsedMs)})`
-      : '';
-  return `Importing character dictionary for ${mediaTitle}${elapsed}...`;
-}
-
-function buildBuildingMessage(mediaTitle: string): string {
-  return `Building character dictionary for ${mediaTitle}...`;
-}
-
-function buildReadyMessage(mediaTitle: string): string {
-  return `Character dictionary ready for ${mediaTitle}`;
-}
-
-function buildFailedMessage(mediaTitle: string | null, errorMessage: string): string {
-  if (mediaTitle) {
-    return `Character dictionary sync failed for ${mediaTitle}: ${errorMessage}`;
-  }
-  return `Character dictionary sync failed: ${errorMessage}`;
-}
-
 export function createCharacterDictionaryAutoSyncRuntimeService(
   deps: CharacterDictionaryAutoSyncRuntimeDeps,
 ): {
@@ -755,8 +677,12 @@ export function createCharacterDictionaryAutoSyncRuntimeService(
               );
             }
             if (merged === null) {
+              // The cached archive only stands in for the recorded state when its own index.json
+              // agrees. A stale or half-written ZIP would be imported under the wrong revision,
+              // and every later sync would then see a revision mismatch and re-import it.
               const existingMergedZipPath = path.join(dictionariesDir, 'merged.zip');
-              if (fs.existsSync(existingMergedZipPath)) {
+              const existingMergedRevision = readDictionaryZipRevision(existingMergedZipPath);
+              if (existingMergedRevision === revision) {
                 merged = {
                   zipPath: existingMergedZipPath,
                   revision,
@@ -764,6 +690,9 @@ export function createCharacterDictionaryAutoSyncRuntimeService(
                   entryCount: snapshot.entryCount,
                 };
               } else {
+                deps.logInfo?.(
+                  `[dictionary:auto-sync] cached merged ZIP unusable (revision ${existingMergedRevision ?? 'unreadable'}, expected ${revision}); rebuilding`,
+                );
                 merged = await deps.buildMergedDictionary(nextActiveMediaIdValues);
               }
             }

--- a/src/main/runtime/character-dictionary-auto-sync.ts
+++ b/src/main/runtime/character-dictionary-auto-sync.ts
@@ -5,8 +5,13 @@ import type { AnilistCharacterDictionaryProfileScope } from '../../types';
 import type {
   CharacterDictionarySnapshotProgressCallbacks,
   CharacterDictionarySnapshotResult,
+  CharacterDictionarySnapshotStageProgress,
   MergedCharacterDictionaryBuildResult,
 } from '../character-dictionary-runtime';
+
+const DEFAULT_IMPORT_TIMEOUT_BASE_MS = 120_000;
+const IMPORT_TIMEOUT_MS_PER_MB = 6_000;
+const IMPORT_TIMEOUT_MAX_MS = 1_800_000;
 
 type AutoSyncMediaEntry = {
   mediaId: number;
@@ -72,7 +77,15 @@ export interface CharacterDictionaryAutoSyncRuntimeDeps {
   now: () => number;
   schedule?: (fn: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
   clearSchedule?: (timer: ReturnType<typeof setTimeout>) => void;
+  /** Budget for the quick Yomitan queries (dictionary info, settings upsert). */
   operationTimeoutMs?: number;
+  /**
+   * Base budget for the slow Yomitan mutations (delete + import). The effective budget grows with
+   * the merged ZIP size, because importing a large dictionary can take several minutes.
+   */
+  dictionaryImportTimeoutBaseMs?: number;
+  heartbeatMs?: number;
+  progressThrottleMs?: number;
   logInfo?: (message: string) => void;
   logWarn?: (message: string) => void;
   onSyncStatus?: (event: CharacterDictionaryAutoSyncStatusEvent) => void;
@@ -353,12 +366,70 @@ function buildCheckingMessage(mediaTitle: string): string {
   return `Checking character dictionary for ${mediaTitle}...`;
 }
 
-function buildGeneratingMessage(mediaTitle: string): string {
-  return `Generating character dictionary for ${mediaTitle}...`;
+function buildGeneratingMessage(mediaTitle: string, detail?: string): string {
+  return detail
+    ? `Generating character dictionary for ${mediaTitle} (${detail})...`
+    : `Generating character dictionary for ${mediaTitle}...`;
 }
 
-function buildImportingMessage(mediaTitle: string): string {
-  return `Importing character dictionary for ${mediaTitle}...`;
+function formatCharacterDictionaryProgressDetail(
+  progress: CharacterDictionarySnapshotStageProgress,
+  remainingMs: number | null,
+): string {
+  if (progress.stage === 'saving') {
+    return 'saving snapshot';
+  }
+  if (progress.stage === 'names') {
+    return progress.total !== null && progress.total > 0
+      ? `name ${progress.completed}/${progress.total}`
+      : `${progress.completed} names`;
+  }
+  if (progress.stage === 'images') {
+    const counted =
+      progress.total !== null && progress.total > 0
+        ? `image ${progress.completed}/${progress.total}`
+        : `${progress.completed} images`;
+    return remainingMs !== null
+      ? `${counted}, ~${formatRemainingDuration(remainingMs)} left`
+      : counted;
+  }
+  const page = typeof progress.page === 'number' ? `page ${progress.page}, ` : '';
+  return `${page}${progress.completed} characters`;
+}
+
+function formatElapsedDuration(elapsedMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m ${String(seconds).padStart(2, '0')}s` : `${seconds}s`;
+}
+
+/** Coarser than the elapsed clock: an estimate that ticks every second reads as precision it lacks. */
+function formatRemainingDuration(remainingMs: number): string {
+  const totalSeconds = Math.max(1, Math.round(remainingMs / 1000));
+  if (totalSeconds >= 60) {
+    return `${Math.max(1, Math.round(totalSeconds / 60))}m`;
+  }
+  return `${Math.max(5, Math.ceil(totalSeconds / 5) * 5)}s`;
+}
+
+/**
+ * The elapsed clock is the part that proves the app is alive: a stalled network fetch freezes the
+ * counts, but the clock keeps moving.
+ */
+function joinGeneratingDetail(detail: string | null, elapsedMs: number): string | undefined {
+  const parts = [detail, elapsedMs >= 5_000 ? formatElapsedDuration(elapsedMs) : null].filter(
+    (part): part is string => typeof part === 'string' && part.length > 0,
+  );
+  return parts.length > 0 ? parts.join(' · ') : undefined;
+}
+
+function buildImportingMessage(mediaTitle: string, elapsedMs?: number): string {
+  const elapsed =
+    typeof elapsedMs === 'number' && elapsedMs >= 1000
+      ? ` (${formatElapsedDuration(elapsedMs)})`
+      : '';
+  return `Importing character dictionary for ${mediaTitle}${elapsed}...`;
 }
 
 function buildBuildingMessage(mediaTitle: string): string {
@@ -389,26 +460,87 @@ export function createCharacterDictionaryAutoSyncRuntimeService(
   const clearSchedule = deps.clearSchedule ?? ((timer) => clearTimeout(timer));
   const debounceMs = 800;
   const operationTimeoutMs = Math.max(1, Math.floor(deps.operationTimeoutMs ?? 7_000));
+  const dictionaryImportTimeoutBaseMs = Math.max(
+    1,
+    Math.floor(deps.dictionaryImportTimeoutBaseMs ?? DEFAULT_IMPORT_TIMEOUT_BASE_MS),
+  );
+  const heartbeatMs = Math.max(1, Math.floor(deps.heartbeatMs ?? 5_000));
+  const progressThrottleMs = Math.max(0, Math.floor(deps.progressThrottleMs ?? 1_000));
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let syncInFlight = false;
   let runQueued = false;
   let activeCurrentMediaId: number | null = null;
 
-  const withOperationTimeout = async <T>(label: string, promise: Promise<T>): Promise<T> => {
+  const withTimeout = async <T>(
+    label: string,
+    promise: Promise<T>,
+    timeoutMs: number,
+  ): Promise<T> => {
     let timer: ReturnType<typeof setTimeout> | null = null;
     try {
       return await Promise.race([
         promise,
         new Promise<never>((_resolve, reject) => {
           timer = setTimeout(() => {
-            reject(new Error(`${label} timed out after ${operationTimeoutMs}ms`));
-          }, operationTimeoutMs);
+            reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+          }, timeoutMs);
         }),
       ]);
     } finally {
       if (timer !== null) {
         clearTimeout(timer);
+      }
+    }
+  };
+
+  const withOperationTimeout = <T>(label: string, promise: Promise<T>): Promise<T> =>
+    withTimeout(label, promise, operationTimeoutMs);
+
+  /**
+   * Importing a merged dictionary means Yomitan writing every term and image into IndexedDB, which
+   * scales with the ZIP: a single-season dictionary lands in seconds, One Piece takes minutes. Size
+   * the budget off the archive instead of failing a healthy import on a flat deadline.
+   */
+  const resolveImportTimeoutMs = (zipPath: string | null): number => {
+    let bytes = 0;
+    if (zipPath) {
+      try {
+        bytes = fs.statSync(zipPath).size;
+      } catch {
+        bytes = 0;
+      }
+    }
+    const sizeAllowanceMs = (bytes / (1024 * 1024)) * IMPORT_TIMEOUT_MS_PER_MB;
+    return Math.min(
+      IMPORT_TIMEOUT_MAX_MS,
+      Math.max(
+        dictionaryImportTimeoutBaseMs,
+        Math.round(dictionaryImportTimeoutBaseMs + sizeAllowanceMs),
+      ),
+    );
+  };
+
+  /** Keeps the persistent notification ticking so a multi-minute import never looks hung. */
+  const withHeartbeat = async <T>(
+    run: () => Promise<T>,
+    onTick: (elapsedMs: number) => void,
+  ): Promise<T> => {
+    const startedAt = deps.now();
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const tick = (): void => {
+      if (stopped) return;
+      onTick(deps.now() - startedAt);
+      timer = schedule(tick, heartbeatMs);
+    };
+    timer = schedule(tick, heartbeatMs);
+    try {
+      return await run();
+    } finally {
+      stopped = true;
+      if (timer !== null) {
+        clearSchedule(timer);
       }
     }
   };
@@ -422,33 +554,112 @@ export function createCharacterDictionaryAutoSyncRuntimeService(
 
     let currentMediaId: number | undefined;
     let currentMediaTitle: string | null = null;
+    let lastProgressAt = Number.NEGATIVE_INFINITY;
+    let lastProgressStage: CharacterDictionarySnapshotStageProgress['stage'] | null = null;
+    let generating: {
+      mediaId: number;
+      mediaTitle: string;
+      startedAt: number;
+      detail: string | null;
+    } | null = null;
+    let imageRate: { startedAt: number; startCompleted: number } | null = null;
+
+    const emitGeneratingStatus = (): void => {
+      if (!generating) {
+        return;
+      }
+      deps.onSyncStatus?.({
+        phase: 'generating',
+        mediaId: generating.mediaId,
+        mediaTitle: generating.mediaTitle,
+        message: buildGeneratingMessage(
+          generating.mediaTitle,
+          joinGeneratingDetail(generating.detail, deps.now() - generating.startedAt),
+        ),
+      });
+    };
+
+    // Image downloads are serial and evenly paced, so the observed rate predicts the tail well.
+    const estimateRemainingImageMs = (
+      progress: CharacterDictionarySnapshotStageProgress,
+      nowMs: number,
+    ): number | null => {
+      if (progress.stage !== 'images' || progress.total === null || imageRate === null) {
+        return null;
+      }
+      const done = progress.completed - imageRate.startCompleted;
+      const elapsedMs = nowMs - imageRate.startedAt;
+      const remaining = progress.total - progress.completed;
+      if (done <= 0 || elapsedMs <= 0 || remaining <= 0) {
+        return null;
+      }
+      return Math.round((elapsedMs / done) * remaining);
+    };
 
     try {
       deps.logInfo?.('[dictionary:auto-sync] syncing current anime snapshot');
-      const snapshot = await deps.getOrCreateCurrentSnapshot(undefined, {
-        onChecking: ({ mediaId, mediaTitle }) => {
-          currentMediaId = mediaId;
-          currentMediaTitle = mediaTitle;
-          activeCurrentMediaId = mediaId;
-          deps.onSyncStatus?.({
-            phase: 'checking',
-            mediaId,
-            mediaTitle,
-            message: buildCheckingMessage(mediaTitle),
-          });
-        },
-        onGenerating: ({ mediaId, mediaTitle }) => {
-          currentMediaId = mediaId;
-          currentMediaTitle = mediaTitle;
-          activeCurrentMediaId = mediaId;
-          deps.onSyncStatus?.({
-            phase: 'generating',
-            mediaId,
-            mediaTitle,
-            message: buildGeneratingMessage(mediaTitle),
-          });
-        },
-      });
+      const snapshot = await withHeartbeat(
+        () =>
+          deps.getOrCreateCurrentSnapshot(undefined, {
+            onChecking: ({ mediaId, mediaTitle }) => {
+              currentMediaId = mediaId;
+              currentMediaTitle = mediaTitle;
+              activeCurrentMediaId = mediaId;
+              deps.onSyncStatus?.({
+                phase: 'checking',
+                mediaId,
+                mediaTitle,
+                message: buildCheckingMessage(mediaTitle),
+              });
+            },
+            onGenerating: ({ mediaId, mediaTitle }) => {
+              currentMediaId = mediaId;
+              currentMediaTitle = mediaTitle;
+              activeCurrentMediaId = mediaId;
+              lastProgressAt = Number.NEGATIVE_INFINITY;
+              lastProgressStage = null;
+              imageRate = null;
+              generating = { mediaId, mediaTitle, startedAt: deps.now(), detail: null };
+              emitGeneratingStatus();
+            },
+            // Long-running work (AniList character pages, then one image download per character
+            // and voice actor, then MeCab name splits) reports counts so the notification shows
+            // movement instead of a frozen "Generating..." for the minutes a large series takes.
+            onGenerateProgress: (progress) => {
+              const nowMs = deps.now();
+              if (!generating) {
+                generating = {
+                  mediaId: progress.mediaId,
+                  mediaTitle: progress.mediaTitle,
+                  startedAt: nowMs,
+                  detail: null,
+                };
+              }
+              if (progress.stage === 'images' && imageRate === null) {
+                imageRate = { startedAt: nowMs, startCompleted: progress.completed };
+              }
+              // Stage changes and the last item of a stage always report; the throttle only thins
+              // out the run of identical-looking updates in between.
+              const isFinal = progress.total !== null && progress.completed >= progress.total;
+              const isStageChange = progress.stage !== lastProgressStage;
+              if (!isFinal && !isStageChange && nowMs - lastProgressAt < progressThrottleMs) {
+                return;
+              }
+              lastProgressAt = nowMs;
+              lastProgressStage = progress.stage;
+              generating.mediaId = progress.mediaId;
+              generating.mediaTitle = progress.mediaTitle;
+              generating.detail = formatCharacterDictionaryProgressDetail(
+                progress,
+                estimateRemainingImageMs(progress, nowMs),
+              );
+              emitGeneratingStatus();
+            },
+          }),
+        // Ticks even when a step stalls, so the message keeps moving while the counts do not.
+        () => emitGeneratingStatus(),
+      );
+      generating = null;
       currentMediaId = snapshot.mediaId;
       currentMediaTitle = snapshot.mediaTitle;
       activeCurrentMediaId = snapshot.mediaId;
@@ -531,33 +742,54 @@ export function createCharacterDictionaryAutoSyncRuntimeService(
           mediaTitle: snapshot.mediaTitle,
           message: buildImportingMessage(snapshot.mediaTitle),
         });
-        if (existing !== null) {
-          await withOperationTimeout(
-            `deleteYomitanDictionary(${dictionaryTitle})`,
-            deps.deleteYomitanDictionary(dictionaryTitle),
-          );
-        }
-        if (merged === null) {
-          const existingMergedZipPath = path.join(dictionariesDir, 'merged.zip');
-          if (fs.existsSync(existingMergedZipPath)) {
-            merged = {
-              zipPath: existingMergedZipPath,
-              revision,
-              dictionaryTitle,
-              entryCount: snapshot.entryCount,
-            };
-          } else {
-            merged = await deps.buildMergedDictionary(nextActiveMediaIdValues);
-          }
-        }
-        deps.logInfo?.(`[dictionary:auto-sync] importing merged dictionary: ${merged.zipPath}`);
-        const imported = await withOperationTimeout(
-          `importYomitanDictionary(${path.basename(merged.zipPath)})`,
-          deps.importYomitanDictionary(merged.zipPath),
+        await withHeartbeat(
+          async () => {
+            const importTimeoutMs = resolveImportTimeoutMs(
+              merged?.zipPath ?? path.join(dictionariesDir, 'merged.zip'),
+            );
+            if (existing !== null) {
+              await withTimeout(
+                `deleteYomitanDictionary(${dictionaryTitle})`,
+                deps.deleteYomitanDictionary(dictionaryTitle),
+                importTimeoutMs,
+              );
+            }
+            if (merged === null) {
+              const existingMergedZipPath = path.join(dictionariesDir, 'merged.zip');
+              if (fs.existsSync(existingMergedZipPath)) {
+                merged = {
+                  zipPath: existingMergedZipPath,
+                  revision,
+                  dictionaryTitle,
+                  entryCount: snapshot.entryCount,
+                };
+              } else {
+                merged = await deps.buildMergedDictionary(nextActiveMediaIdValues);
+              }
+            }
+            const mergedZipPath = merged.zipPath;
+            const mergedImportTimeoutMs = resolveImportTimeoutMs(mergedZipPath);
+            deps.logInfo?.(
+              `[dictionary:auto-sync] importing merged dictionary: ${mergedZipPath} (timeout ${mergedImportTimeoutMs}ms)`,
+            );
+            const imported = await withTimeout(
+              `importYomitanDictionary(${path.basename(mergedZipPath)})`,
+              deps.importYomitanDictionary(mergedZipPath),
+              mergedImportTimeoutMs,
+            );
+            if (!imported) {
+              throw new Error(`Failed to import dictionary ZIP: ${merged.zipPath}`);
+            }
+          },
+          (elapsedMs) => {
+            deps.onSyncStatus?.({
+              phase: 'importing',
+              mediaId: snapshot.mediaId,
+              mediaTitle: snapshot.mediaTitle,
+              message: buildImportingMessage(snapshot.mediaTitle, elapsedMs),
+            });
+          },
         );
-        if (!imported) {
-          throw new Error(`Failed to import dictionary ZIP: ${merged.zipPath}`);
-        }
         changed = true;
       }
 

--- a/src/main/runtime/startup-osd-sequencer.ts
+++ b/src/main/runtime/startup-osd-sequencer.ts
@@ -10,7 +10,7 @@ export interface StartupOsdSequencerDeps {
   getNotificationType?: () => NotificationType | undefined;
   showOsd: (message: string) => boolean | void;
   showOverlayNotification?: (payload: OverlayNotificationPayload) => void;
-  showDesktopNotification?: (title: string, options: { body?: string }) => void;
+  showDesktopNotification?: (title: string, options: { body?: string; replaceId?: string }) => void;
 }
 
 interface StartupStatusNotificationOptions {
@@ -62,7 +62,11 @@ export function createStartupOsdSequencer(deps: StartupOsdSequencerDeps): {
       shown = deps.showOsd(options.message) !== false || shown;
     }
     if (options.desktop !== false && shouldShowDesktop(type)) {
-      deps.showDesktopNotification?.('SubMiner', { body: options.message });
+      // Each startup lane keeps one live desktop notification instead of one per update.
+      deps.showDesktopNotification?.('SubMiner', {
+        body: options.message,
+        replaceId: options.id,
+      });
       shown = true;
     }
     return shown;

--- a/src/shared/stored-zip.ts
+++ b/src/shared/stored-zip.ts
@@ -148,6 +148,62 @@ function createEndOfCentralDirectory(
   return end;
 }
 
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const LOCAL_FILE_HEADER_SIZE = 30;
+
+/**
+ * Reads the first entry of an archive written by {@link writeStoredZip}: every entry is stored
+ * uncompressed with no extra field and no data descriptor, so the leading local header is enough.
+ * Returns null for anything it does not recognize, so callers treat a corrupt or foreign archive
+ * the same as a missing one.
+ */
+export function readStoredZipFirstFile(zipPath: string): StoredZipFile | null {
+  let fd: number;
+  try {
+    fd = fs.openSync(zipPath, 'r');
+  } catch {
+    return null;
+  }
+
+  try {
+    const fileSize = fs.fstatSync(fd).size;
+    const header = Buffer.alloc(LOCAL_FILE_HEADER_SIZE);
+    if (fs.readSync(fd, header, 0, header.length, 0) !== header.length) {
+      return null;
+    }
+    if (header.readUInt32LE(0) !== LOCAL_FILE_HEADER_SIGNATURE) {
+      return null;
+    }
+    // Compression method 0 (stored) is the only thing writeStoredZip emits.
+    if (header.readUInt16LE(8) !== 0) {
+      return null;
+    }
+    const entrySize = header.readUInt32LE(18);
+    const nameLength = header.readUInt16LE(26);
+    const extraLength = header.readUInt16LE(28);
+    const dataOffset = LOCAL_FILE_HEADER_SIZE + nameLength + extraLength;
+    if (dataOffset + entrySize > fileSize) {
+      return null;
+    }
+    const name = Buffer.alloc(nameLength);
+    if (
+      nameLength > 0 &&
+      fs.readSync(fd, name, 0, nameLength, LOCAL_FILE_HEADER_SIZE) !== nameLength
+    ) {
+      return null;
+    }
+    const data = Buffer.alloc(entrySize);
+    if (entrySize > 0 && fs.readSync(fd, data, 0, entrySize, dataOffset) !== entrySize) {
+      return null;
+    }
+    return { name: name.toString('utf8'), data };
+  } catch {
+    return null;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 function writeBuffer(fd: number, buffer: Buffer): void {
   let written = 0;
   while (written < buffer.length) {

--- a/src/shared/stored-zip.ts
+++ b/src/shared/stored-zip.ts
@@ -152,6 +152,50 @@ const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
 const LOCAL_FILE_HEADER_SIZE = 30;
 const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
 const END_OF_CENTRAL_DIRECTORY_SIZE = 22;
+const CENTRAL_FILE_HEADER_SIGNATURE = 0x02014b50;
+const CENTRAL_FILE_HEADER_SIZE = 46;
+// 65535 entries with names of a few dozen bytes stay far under this; the cap only stops a corrupt
+// record length from asking for an allocation the size of the archive.
+const MAX_CENTRAL_DIRECTORY_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Walks every declared central-directory record, checking each signature and keeping the
+ * variable-length name/extra/comment fields inside the directory. The walk has to land exactly on
+ * the end of the directory, so a record that was overwritten in place fails even though the file
+ * kept its size.
+ */
+function isCentralDirectoryIntact(
+  fd: number,
+  centralStart: number,
+  centralSize: number,
+  entryCount: number,
+): boolean {
+  if (centralSize === 0 || centralSize > MAX_CENTRAL_DIRECTORY_BYTES) {
+    return false;
+  }
+  const central = Buffer.alloc(centralSize);
+  if (fs.readSync(fd, central, 0, centralSize, centralStart) !== centralSize) {
+    return false;
+  }
+
+  let cursor = 0;
+  for (let index = 0; index < entryCount; index += 1) {
+    if (cursor + CENTRAL_FILE_HEADER_SIZE > centralSize) {
+      return false;
+    }
+    if (central.readUInt32LE(cursor) !== CENTRAL_FILE_HEADER_SIGNATURE) {
+      return false;
+    }
+    const nameLength = central.readUInt16LE(cursor + 28);
+    const extraLength = central.readUInt16LE(cursor + 30);
+    const commentLength = central.readUInt16LE(cursor + 32);
+    cursor += CENTRAL_FILE_HEADER_SIZE + nameLength + extraLength + commentLength;
+    if (cursor > centralSize) {
+      return false;
+    }
+  }
+  return cursor === centralSize;
+}
 
 /**
  * Start of the central directory, or null when the archive is not a complete one of ours. The
@@ -171,12 +215,16 @@ function readCentralDirectoryStart(fd: number, fileSize: number): number | null 
   if (end.readUInt32LE(0) !== END_OF_CENTRAL_DIRECTORY_SIGNATURE || end.readUInt16LE(20) !== 0) {
     return null;
   }
-  if (end.readUInt16LE(10) === 0) {
+  const entryCount = end.readUInt16LE(10);
+  if (entryCount === 0) {
     return null;
   }
   const centralSize = end.readUInt32LE(12);
   const centralStart = end.readUInt32LE(16);
   if (centralStart + centralSize !== endOffset) {
+    return null;
+  }
+  if (!isCentralDirectoryIntact(fd, centralStart, centralSize, entryCount)) {
     return null;
   }
   return centralStart;

--- a/src/shared/stored-zip.ts
+++ b/src/shared/stored-zip.ts
@@ -150,12 +150,43 @@ function createEndOfCentralDirectory(
 
 const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
 const LOCAL_FILE_HEADER_SIZE = 30;
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const END_OF_CENTRAL_DIRECTORY_SIZE = 22;
+
+/**
+ * Start of the central directory, or null when the archive is not a complete one of ours. The
+ * end-of-central-directory record is written last, so finding an intact one is what separates a
+ * finished archive from a half-written one.
+ */
+function readCentralDirectoryStart(fd: number, fileSize: number): number | null {
+  if (fileSize < END_OF_CENTRAL_DIRECTORY_SIZE) {
+    return null;
+  }
+  const end = Buffer.alloc(END_OF_CENTRAL_DIRECTORY_SIZE);
+  const endOffset = fileSize - END_OF_CENTRAL_DIRECTORY_SIZE;
+  if (fs.readSync(fd, end, 0, end.length, endOffset) !== end.length) {
+    return null;
+  }
+  // writeStoredZip never writes an archive comment, so the record is exactly the last 22 bytes.
+  if (end.readUInt32LE(0) !== END_OF_CENTRAL_DIRECTORY_SIGNATURE || end.readUInt16LE(20) !== 0) {
+    return null;
+  }
+  if (end.readUInt16LE(10) === 0) {
+    return null;
+  }
+  const centralSize = end.readUInt32LE(12);
+  const centralStart = end.readUInt32LE(16);
+  if (centralStart + centralSize !== endOffset) {
+    return null;
+  }
+  return centralStart;
+}
 
 /**
  * Reads the first entry of an archive written by {@link writeStoredZip}: every entry is stored
  * uncompressed with no extra field and no data descriptor, so the leading local header is enough.
- * Returns null for anything it does not recognize, so callers treat a corrupt or foreign archive
- * the same as a missing one.
+ * Returns null for anything it does not recognize, so callers treat a corrupt, truncated, or
+ * foreign archive the same as a missing one.
  */
 export function readStoredZipFirstFile(zipPath: string): StoredZipFile | null {
   let fd: number;
@@ -167,6 +198,10 @@ export function readStoredZipFirstFile(zipPath: string): StoredZipFile | null {
 
   try {
     const fileSize = fs.fstatSync(fd).size;
+    const centralStart = readCentralDirectoryStart(fd, fileSize);
+    if (centralStart === null) {
+      return null;
+    }
     const header = Buffer.alloc(LOCAL_FILE_HEADER_SIZE);
     if (fs.readSync(fd, header, 0, header.length, 0) !== header.length) {
       return null;
@@ -182,7 +217,7 @@ export function readStoredZipFirstFile(zipPath: string): StoredZipFile | null {
     const nameLength = header.readUInt16LE(26);
     const extraLength = header.readUInt16LE(28);
     const dataOffset = LOCAL_FILE_HEADER_SIZE + nameLength + extraLength;
-    if (dataOffset + entrySize > fileSize) {
+    if (dataOffset + entrySize > centralStart) {
       return null;
     }
     const name = Buffer.alloc(nameLength);


### PR DESCRIPTION
## Summary

Large character dictionaries (e.g. One Piece: 33 AniList pages, 1220 character/voice-actor images) failed to install because the Yomitan import (and the delete that precedes it) used a flat 7 second budget, throwing `importYomitanDictionary(merged.zip) timed out after 7000ms` even though the import was still healthy. The import/delete timeout is now sized from the merged ZIP (2 minutes base + 6 seconds per MB, capped at 30 minutes); quick queries keep the 7 second budget.

The "Generating character dictionary" notification also now reports what stage it's in instead of one static message for the whole run: AniList page and character count while characters download, then `image N/total, ~Xm left` per image, then `name N/total` for MeCab name splits and `saving snapshot` at the end. Updates are throttled to one per second, but every stage change and the final item always report. Long phases (generating and importing) carry an elapsed clock that ticks every 5 seconds even when nothing else moves, so a stalled step reads differently from a frozen app.

Also drops the X11 backend's forced `--vo=gpu --gpu-api=opengl` fallback (unrelated cleanup carried in this branch): only the window context (`--gpu-context=x11egl,x11`) is pinned now, so a `vo=gpu-next` config keeps its renderer/API/user shaders on XWayland.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Other

## Related issues

None.

## How was this tested?

Added/updated unit tests covering: size-scaled import timeout budget, a real-hang case reporting the scaled budget, the importing notification ticking on a heartbeat, character/image/name stage progress reporting (with throttling), and the generating clock ticking through a stalled stage. Also updated `launcher/mpv.test.ts` and `src/shared/mpv-x11-backend.test.ts` for the X11 GPU context change.

- `bun run typecheck && bun run test:fast && bun run test:env && bun run build && bun run test:smoke:dist`

## Checklist

- [x] Reconciled current-outcome changelog fragment(s), or this PR is labeled `skip-changelog` (see [`changes/README.md`](../changes/README.md))
- [x] Docs updated in the same PR if behavior, defaults, flags, shortcuts, ports, or APIs changed
- [x] Relevant checks pass locally (typecheck, tests, build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed progress updates for character fetching, image downloads, name resolution, saving, and importing.
  * Progress messages now include completed counts, totals, page numbers, elapsed time, and estimated remaining download time.
  * Added heartbeat updates during lengthy imports and snapshot generation.
  * Import timeouts now scale with dictionary size.
  * Desktop notifications now update existing messages instead of creating duplicates.

* **Bug Fixes**
  * Stale, revision-mismatched, invalid, or incomplete cached archives are safely rebuilt or rejected.
  * Improved reliability of readiness and progress reporting during long-running dictionary operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->