### PR TITLE
fix(overlay): support native Wayland file drag-and-drop

### DIFF
--- a/changes/fix-native-wayland-overlay-file-drop.md
+++ b/changes/fix-native-wayland-overlay-file-drop.md
@@ -1,0 +1,4 @@
+type: fixed
+area: overlay
+
+- Fixed native Wayland drag-and-drop from file managers such as Thunar so subtitle and video files dropped on the visible overlay are resolved and forwarded to mpv.

--- a/src/core/services/overlay-drop.test.ts
+++ b/src/core/services/overlay-drop.test.ts
@@ -30,6 +30,16 @@ test('collectDroppedVideoPaths keeps supported dropped file paths in order', () 
   assert.deepEqual(result, ['/videos/ep02.mkv', '/videos/ep03.MP4']);
 });
 
+test('collectDroppedVideoPaths accepts paths resolved from standard Web File objects', () => {
+  const transfer = makeTransfer({
+    files: [{ name: 'ep02.mkv' }, { name: 'notes.txt' }],
+  });
+
+  const result = collectDroppedVideoPaths(transfer, ['/videos/ep02.mkv', '/videos/notes.txt']);
+
+  assert.deepEqual(result, ['/videos/ep02.mkv']);
+});
+
 test('collectDroppedVideoPaths parses text/uri-list entries and de-duplicates', () => {
   const transfer = makeTransfer({
     getData: (format: string) =>

--- a/src/core/services/overlay-drop.test.ts
+++ b/src/core/services/overlay-drop.test.ts
@@ -53,6 +53,20 @@ test('collectDroppedSubtitlePaths keeps supported dropped subtitle paths in orde
   assert.deepEqual(result, ['/subs/ep02.ass', '/subs/ep03.SRT']);
 });
 
+test('collectDroppedSubtitlePaths accepts paths resolved from standard Web File objects', () => {
+  const transfer = makeTransfer({
+    files: [{ name: 'ep02.ass' }, { name: 'readme.txt' }, { name: 'ep03.SRT' }],
+  });
+
+  const result = collectDroppedSubtitlePaths(transfer, [
+    '/subs/ep02.ass',
+    '/subs/readme.txt',
+    '/subs/ep03.SRT',
+  ]);
+
+  assert.deepEqual(result, ['/subs/ep02.ass', '/subs/ep03.SRT']);
+});
+
 test('collectDroppedSubtitlePaths parses text/uri-list entries and de-duplicates', () => {
   const transfer = makeTransfer({
     getData: (format: string) =>

--- a/src/core/services/overlay-drop.ts
+++ b/src/core/services/overlay-drop.ts
@@ -93,18 +93,21 @@ export function parseClipboardVideoPath(text: string): string | null {
 
 export function collectDroppedVideoPaths(
   dataTransfer: DropDataTransferLike | null | undefined,
+  resolvedFilePaths: ArrayLike<string> = [],
 ): string[] {
-  return collectDroppedPaths(dataTransfer, isSupportedVideoPath);
+  return collectDroppedPaths(dataTransfer, resolvedFilePaths, isSupportedVideoPath);
 }
 
 export function collectDroppedSubtitlePaths(
   dataTransfer: DropDataTransferLike | null | undefined,
+  resolvedFilePaths: ArrayLike<string> = [],
 ): string[] {
-  return collectDroppedPaths(dataTransfer, isSupportedSubtitlePath);
+  return collectDroppedPaths(dataTransfer, resolvedFilePaths, isSupportedSubtitlePath);
 }
 
 function collectDroppedPaths(
   dataTransfer: DropDataTransferLike | null | undefined,
+  resolvedFilePaths: ArrayLike<string>,
   isSupportedPath: (pathValue: string) => boolean,
 ): string[] {
   if (!dataTransfer) return [];
@@ -124,6 +127,7 @@ function collectDroppedPaths(
     for (let i = 0; i < dataTransfer.files.length; i += 1) {
       const file = dataTransfer.files[i] as { path?: string } | undefined;
       addPath(file?.path);
+      addPath(resolvedFilePaths[i]);
     }
   }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
+import { contextBridge, ipcRenderer, IpcRendererEvent, webUtils } from 'electron';
 import { resolveOverlayLayerFromArgv } from './preload-args';
 import type {
   SubtitleData,
@@ -248,6 +248,7 @@ const onSecondarySubtitleModeEvent = createLatestValueIpcListenerWithPayload<Sec
 
 const electronAPI: ElectronAPI = {
   getOverlayLayer: () => overlayLayer,
+  getPathForFile: (file: File) => webUtils.getPathForFile(file),
   onSubtitle: (callback: (data: SubtitleData) => void) => {
     onSubtitleSetEvent(callback);
   },

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -899,8 +899,11 @@ function setupDragDropToMpvQueue(): void {
     if (!event.dataTransfer) return;
     event.preventDefault();
 
-    const droppedVideoPaths = collectDroppedVideoPaths(event.dataTransfer);
-    const droppedSubtitlePaths = collectDroppedSubtitlePaths(event.dataTransfer);
+    const resolvedFilePaths = Array.from(event.dataTransfer.files, (file) =>
+      window.electronAPI.getPathForFile(file),
+    );
+    const droppedVideoPaths = collectDroppedVideoPaths(event.dataTransfer, resolvedFilePaths);
+    const droppedSubtitlePaths = collectDroppedSubtitlePaths(event.dataTransfer, resolvedFilePaths);
     const appendDroppedVideos = event.shiftKey;
     const loadCommands = buildMpvLoadfileCommands(droppedVideoPaths, appendDroppedVideos);
     const subtitleCommands = buildMpvSubtitleAddCommands(droppedSubtitlePaths);

--- a/src/types/runtime.ts
+++ b/src/types/runtime.ts
@@ -425,6 +425,7 @@ export interface SessionNumericSelectionStartPayload {
 
 export interface ElectronAPI {
   getOverlayLayer: () => 'visible' | 'modal' | null;
+  getPathForFile: (file: File) => string;
   onSubtitle: (callback: (data: SubtitleData) => void) => void;
   onOverlayPointerRecoveryRequested: (callback: () => void) => void;
   onOverlayNotification: (callback: (payload: OverlayNotificationEventPayload) => void) => void;


### PR DESCRIPTION
## Summary

Fix native Wayland drag-and-drop from file managers such as Thunar by resolving dropped file paths through Electron and forwarding supported subtitle and video files to mpv.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Other

## Related issues

## How was this tested?

Added focused unit coverage confirming that paths resolved from standard Web File objects are accepted and filtered correctly. Broader verification was not run for this change.

## Checklist

- [x] Reconciled current-outcome changelog fragment(s), or this PR is labeled `skip-changelog` (see [`changes/README.md`](../changes/README.md))
- [x] Docs updated in the same PR if behavior, defaults, flags, shortcuts, ports, or APIs changed
- [ ] Relevant checks pass locally (typecheck, tests, build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop handling for video and subtitle files.
  * Dropped files now resolve to their correct filesystem paths, including standard Web `File` objects.
  * Unsupported file types remain filtered out, while supported files retain their original order and duplicate protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->