### PR TITLE
fix(mining): copy multi-line subtitles backward from current line

### DIFF
--- a/changes/multiline-copy-timeline.md
+++ b/changes/multiline-copy-timeline.md
@@ -1,4 +1,4 @@
 type: fixed
 area: mining
 
-- Multi-line copy and mining now select backward from the current subtitle in timeline order after seeking, instead of copying lines in playback encounter order.
+- Multi-line copy and mining now select backward from the current subtitle in timeline order after seeking, instead of copying lines in playback encounter order. Jumping back to a short previous line also counts as a seek with external subtitle files, so that line becomes the current one.

--- a/changes/multiline-copy-timeline.md
+++ b/changes/multiline-copy-timeline.md
@@ -1,0 +1,4 @@
+type: fixed
+area: mining
+
+- Multi-line copy and mining now select backward from the current subtitle in timeline order after seeking, instead of copying lines in playback encounter order.

--- a/docs-site/shortcuts.md
+++ b/docs-site/shortcuts.md
@@ -35,7 +35,7 @@ These work when the overlay window has focus.
 | `Ctrl/Cmd+G`       | Trigger field grouping (Kiku merge check)       | `shortcuts.triggerFieldGrouping`        |
 | `Ctrl/Cmd+Shift+A` | Mark last card as audio card                    | `shortcuts.markAudioCard`               |
 
-The multi-line shortcuts open a digit selector with a 3-second timeout (`shortcuts.multiCopyTimeoutMs`). Press `1`–`9` to select how many recent subtitle lines to combine. When the shortcut starts from mpv, SubMiner focuses the visible overlay for that selector instead of reserving the number keys in the mpv plugin.
+The multi-line shortcuts open a digit selector with a 3-second timeout (`shortcuts.multiCopyTimeoutMs`). Press `1`–`9` to select the total number of subtitle lines to combine, ending at the current line and moving backward through the subtitle timeline. The current line counts toward the selected total. When the shortcut starts from mpv, SubMiner focuses the visible overlay for that selector instead of reserving the number keys in the mpv plugin.
 
 ## Overlay Controls
 

--- a/src/core/services/mining.test.ts
+++ b/src/core/services/mining.test.ts
@@ -373,6 +373,22 @@ test('handleMineSentenceDigit keeps per-entry timings when subtitle text repeats
   }
 });
 
+test('subtitle timing history preserves adjacent repeated text with distinct timings', () => {
+  const tracker = new SubtitleTimingTracker();
+
+  try {
+    tracker.recordSubtitle('same', 1, 2);
+    tracker.recordSubtitle('same', 3, 4);
+
+    assert.deepEqual(tracker.getRecentEntries(2), [
+      { displayText: 'same', startTime: 1, endTime: 2, secondaryText: undefined },
+      { displayText: 'same', startTime: 3, endTime: 4, secondaryText: undefined },
+    ]);
+  } finally {
+    tracker.destroy();
+  }
+});
+
 test('handleMineSentenceDigit joins per-entry secondary subtitles when available', async () => {
   const created: Array<{ sentence: string; secondarySub?: string }> = [];
   const tracker = new SubtitleTimingTracker();

--- a/src/core/services/mining.test.ts
+++ b/src/core/services/mining.test.ts
@@ -244,6 +244,35 @@ test('handleMultiCopyDigit copies available history and reports truncation', () 
   assert.equal(osd.at(-1), 'Only 2 lines available, copied 2');
 });
 
+test('handleMultiCopyDigit copies backward from the current subtitle after a backward seek', () => {
+  const copied: string[] = [];
+  const tracker = new SubtitleTimingTracker();
+
+  try {
+    tracker.recordSubtitle('A', 1, 2);
+    tracker.recordSubtitle('B', 3, 4);
+    tracker.recordSubtitle('C', 5, 6);
+    tracker.recordSubtitle('B', 3, 4);
+
+    const deps = {
+      subtitleTimingTracker: tracker,
+      writeClipboardText: (text: string) => copied.push(text),
+      showMpvOsd: () => {},
+    };
+
+    handleMultiCopyDigit(1, deps);
+    handleMultiCopyDigit(2, deps);
+
+    assert.deepEqual(copied, ['B', 'A\n\nB']);
+    assert.deepEqual(tracker.getRecentEntries(2), [
+      { displayText: 'A', startTime: 1, endTime: 2, secondaryText: undefined },
+      { displayText: 'B', startTime: 3, endTime: 4, secondaryText: undefined },
+    ]);
+  } finally {
+    tracker.destroy();
+  }
+});
+
 test('handleMineSentenceDigit reports async create failures', async () => {
   const osd: string[] = [];
   const logs: Array<{ message: string; err: unknown }> = [];

--- a/src/main/runtime/mpv-main-event-main-deps.test.ts
+++ b/src/main/runtime/mpv-main-event-main-deps.test.ts
@@ -503,13 +503,20 @@ test('canonical ASS cues replace live glyph spam for display, history, and immer
   assert.deepEqual(timing.slice(3), [{ text: '今　手にある物差しでは', start: 1.2, end: 3.8 }]);
   assert.equal(immersion.length, 3);
 
-  // A jump of exactly the seek threshold counts as a seek, matching the time-pos
-  // handler's own `>=` boundary.
-  handlers.onTimePosUpdate?.(4.5);
-  handlers.onTimePosUpdate?.(2);
+  // Jumping back to a brief previous line moves time-pos by less than the general
+  // seek threshold. It is still a backward seek, so the revisited line records
+  // again; otherwise multi-line copy would keep treating the later line as current.
+  handlers.onTimePosUpdate?.(3.9);
+  handlers.onTimePosUpdate?.(2.9);
   handlers.recordSubtitleTiming('今', 0.8, 1.5);
 
   assert.deepEqual(timing.slice(4), [{ text: '今　手にある物差しでは', start: 1.2, end: 3.8 }]);
+
+  // Tiny time-pos jitter is not a seek and must not re-record the line.
+  handlers.onTimePosUpdate?.(3.0);
+  handlers.onTimePosUpdate?.(2.9);
+  handlers.recordSubtitleTiming('今', 0.8, 1.5);
+  assert.equal(timing.length, 5);
 
   handlers.recordImmersionSubtitleLine('Maid\nCafe', 10, 12);
   handlers.recordSubtitleTiming('Maid\nCafe', 10, 12);

--- a/src/main/runtime/mpv-main-event-main-deps.ts
+++ b/src/main/runtime/mpv-main-event-main-deps.ts
@@ -1,6 +1,5 @@
 import { createSubtitleLineDedupGate } from '../../core/services/subtitle-line-dedup-gate';
 import type { MergedToken, SubtitleCue, SubtitleData } from '../../types';
-import { SEEK_LIKE_TIME_DELTA_SECONDS } from './mpv-main-event-actions';
 import {
   resolveCanonicalPrimarySubtitle,
   resolvePrimarySubtitleText,
@@ -115,6 +114,8 @@ export function createBuildBindMpvMainEventHandlersMainDepsHandler(deps: {
   // after the change is dropped instead of landing in the next session.
   let subtitleSessionEpoch = 0;
   let lastTimePosForTimingReset: number | null = null;
+  // Small margin so time-pos jitter is not mistaken for a backward seek.
+  const BACKWARD_SEEK_TIMING_RESET_SECONDS = 0.25;
   const canonicalCueKey = (cue: SubtitleCue): string =>
     `${cue.startTime}|${cue.endTime}|${cue.text}`;
   const resetSubtitleDeduplication = (): void => {
@@ -344,13 +345,15 @@ export function createBuildBindMpvMainEventHandlersMainDepsHandler(deps: {
       deps.reportJellyfinRemoteProgress(forceImmediate),
     consumeExplicitSeek: deps.consumeExplicitSeek,
     onTimePosUpdate: (time: number) => {
-      // Timing history is a viewing log: after a real backward seek, a rewatched
-      // canonical line should enter it again. Immersion stats keep their
-      // once-per-media deduplication and are not reset here.
+      // Timing history is a viewing log: after any backward seek, a rewatched canonical
+      // line should enter it again so multi-line copy treats it as the current line.
+      // Playback never moves time-pos backward on its own, so even a short jump to a
+      // brief previous line counts. Immersion stats keep their once-per-media
+      // deduplication and are not reset here.
       if (
         Number.isFinite(time) &&
         lastTimePosForTimingReset !== null &&
-        time <= lastTimePosForTimingReset - SEEK_LIKE_TIME_DELTA_SECONDS
+        time <= lastTimePosForTimingReset - BACKWARD_SEEK_TIMING_RESET_SECONDS
       ) {
         recordedTimingCanonicalKeys.clear();
       }

--- a/src/subtitle-timing-tracker.ts
+++ b/src/subtitle-timing-tracker.ts
@@ -67,8 +67,13 @@ export class SubtitleTimingTracker {
 
     // Check for duplicate of most recent entry (deduplicate adjacent repeats)
     const lastEntry = this.history[this.history.length - 1];
-    if (lastEntry && lastEntry.timingKey === timingKey) {
-      // Update timing to most recent occurrence
+    if (
+      lastEntry &&
+      lastEntry.timingKey === timingKey &&
+      lastEntry.startTime === startTime &&
+      lastEntry.endTime === endTime
+    ) {
+      // Refresh metadata for repeated notifications of the same subtitle event.
       lastEntry.startTime = startTime;
       lastEntry.endTime = endTime;
       lastEntry.secondaryText = displaySecondaryText;

--- a/src/subtitle-timing-tracker.ts
+++ b/src/subtitle-timing-tracker.ts
@@ -107,28 +107,20 @@ export class SubtitleTimingTracker {
   }
 
   /**
-   * Get recent subtitle blocks in chronological order.
-   * Returns the last `count` subtitle events (oldest → newest).
+   * Get recent subtitle blocks in timeline order.
+   * Returns up to `count` known subtitle events ending at the current event.
    * Blocks preserve internal line breaks and are joined with blank lines.
    */
   getRecentBlocks(count: number): string[] {
-    if (count <= 0) return [];
-    if (count > this.history.length) {
-      count = this.history.length;
-    }
-    return this.history.slice(-count).map((entry) => entry.displayText);
+    return this.getRecentTimelineEntries(count).map((entry) => entry.displayText);
   }
 
   /**
-   * Get recent subtitle blocks with their original event timings.
-   * Returns the last `count` subtitle events (oldest → newest).
+   * Get recent subtitle blocks with their original event timings in timeline order.
+   * Returns up to `count` known subtitle events ending at the current event.
    */
   getRecentEntries(count: number): SubtitleTimingBlock[] {
-    if (count <= 0) return [];
-    if (count > this.history.length) {
-      count = this.history.length;
-    }
-    return this.history.slice(-count).map((entry) => ({
+    return this.getRecentTimelineEntries(count).map((entry) => ({
       displayText: entry.displayText,
       startTime: entry.startTime,
       endTime: entry.endTime,
@@ -142,6 +134,43 @@ export class SubtitleTimingTracker {
   getCurrentSubtitle(): string | null {
     const lastEntry = this.history[this.history.length - 1];
     return lastEntry ? lastEntry.displayText : null;
+  }
+
+  private getRecentTimelineEntries(count: number): HistoryEntry[] {
+    if (count <= 0) return [];
+
+    const currentEntry = this.history[this.history.length - 1];
+    if (!currentEntry) return [];
+
+    const timelineEntries: HistoryEntry[] = [];
+    for (const entry of this.history) {
+      const existingIndex = timelineEntries.findIndex((candidate) =>
+        this.isSameSubtitleEvent(candidate, entry),
+      );
+      if (existingIndex === -1) {
+        timelineEntries.push(entry);
+      } else {
+        timelineEntries[existingIndex] = entry;
+      }
+    }
+
+    timelineEntries.sort(
+      (left, right) => left.startTime - right.startTime || left.endTime - right.endTime,
+    );
+    const currentIndex = timelineEntries.findIndex((entry) =>
+      this.isSameSubtitleEvent(entry, currentEntry),
+    );
+    if (currentIndex === -1) return [];
+
+    return timelineEntries.slice(Math.max(0, currentIndex - count + 1), currentIndex + 1);
+  }
+
+  private isSameSubtitleEvent(left: HistoryEntry, right: HistoryEntry): boolean {
+    return (
+      left.timingKey === right.timingKey &&
+      left.startTime === right.startTime &&
+      left.endTime === right.endTime
+    );
   }
 
   private findFuzzyMatch(text: string): { startTime: number; endTime: number } | null {


### PR DESCRIPTION
## Summary

Fix multi-line copy and mining after seeking backward so selections end at the current subtitle and move backward through the subtitle timeline. Adds regression coverage and updates the shortcut documentation.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [ ] Documentation
- [ ] Other

## How was this tested?

Added a focused mining regression test covering backward seeks and timeline-ordered multi-line copying.

## Checklist

- [x] Reconciled current-outcome changelog fragment(s), or this PR is labeled `skip-changelog` (see [`changes/README.md`](../changes/README.md))
- [x] Docs updated in the same PR if behavior, defaults, flags, shortcuts, ports, or APIs changed
- [ ] Relevant checks pass locally (typecheck, tests, build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-copy subtitle selection after seeking, including small backward seeks, so the current subtitle is copied first, followed by preceding subtitles in timeline order.
  * Preserved each subtitle’s individual timing information, including adjacent entries with identical text.
  * Removed duplicate subtitle events only when their text and timing match.
  * Prevented minor playback-position jitter from creating duplicate subtitle records.
  * Improved recent subtitle retrieval by maintaining chronological order and excluding repeated timeline events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->