### PR TITLE
docs(anki): clarify sentence audio field placement

### DIFF
--- a/changes/preserve-word-audio.md
+++ b/changes/preserve-word-audio.md
@@ -1,0 +1,4 @@
+type: docs
+area: anki
+
+- Clarify that the configured Anki audio field receives sentence clips, including media timing review, and should be separate from Yomitan's word pronunciation field.

--- a/docs-site/anki-integration.md
+++ b/docs-site/anki-integration.md
@@ -138,6 +138,8 @@ Field names are matched against your Anki note type case-insensitively (an exact
 
 These mappings always control normal word-card enrichment, including Yomitan proxy/polling updates and manual clipboard updates. Enabling Lapis or Kiku does not replace the configured word-card sentence and audio fields with `Sentence` and `SentenceAudio`. The dedicated sentence-card and audio-card shortcuts still use those Lapis/Kiku field names.
 
+The audio field receives the sentence clip from the video, including when media timing review is enabled. In Settings, set the Anki audio field to your note type's sentence-audio field, such as `SentenceAudio`, and keep it separate from the field Yomitan uses for word pronunciation. If both write to the same field, SubMiner can overwrite the pronunciation audio. Changing the mapping affects future updates; existing cards need their word audio restored separately.
+
 Two related options live alongside `fields`: `ankiConnect.deck` (target deck; empty falls back as described above) and `ankiConnect.tags` (tags added to mined cards, default `["SubMiner"]`; set `[]` to disable tagging). The `miscInfo` content is controlled by `ankiConnect.metadata.pattern` (default `[SubMiner] %f (%t)`; tokens: `%f` filename, `%F` filename with extension, `%t` timestamp, `%T` timestamp with milliseconds, `<br>` newline).
 
 ### Minimal Config

--- a/src/anki-integration/note-update-workflow.test.ts
+++ b/src/anki-integration/note-update-workflow.test.ts
@@ -121,6 +121,51 @@ test('NoteUpdateWorkflow updates sentence field and emits notification', async (
   assert.equal(harness.notifications.length, 1);
 });
 
+for (const audioField of ['SentenceAudio', 'ContextAudio']) {
+  for (const action of ['confirm', 'use-original'] as const) {
+    test(`NoteUpdateWorkflow respects the configured ${audioField} field with ${action} timing`, async () => {
+      const harness = createWorkflowHarness();
+      harness.deps.getConfig = () => ({
+        fields: { sentence: 'Sentence', audio: audioField },
+        media: { generateAudio: true, generateImage: false },
+      });
+      harness.deps.client.notesInfo = async () => [
+        {
+          noteId: 42,
+          fields: {
+            Expression: { value: 'taberu' },
+            ExpressionAudio: { value: '[sound:word.mp3]' },
+            Sentence: { value: '' },
+            SentenceAudio: { value: '' },
+            ContextAudio: { value: '' },
+          },
+        },
+      ];
+      harness.deps.captureSubtitleMediaContext = () => ({
+        source: 'overlay',
+        text: 'subtitle-text',
+        startTime: 4,
+        endTime: 6,
+      });
+      harness.deps.reviewMediaTiming = async () => ({
+        action,
+        startTime: 4.2,
+        endTime: 5.8,
+      });
+      harness.deps.generateAudio = async () => Buffer.from('sentence audio');
+
+      await harness.workflow.execute(42);
+
+      assert.equal(harness.updates.length, 1);
+      assert.equal(harness.updates[0]?.fields.ExpressionAudio, undefined);
+      assert.deepEqual(harness.updates[0]?.fields, {
+        Sentence: 'subtitle-text',
+        [audioField]: '[sound:audio_1.mp3]',
+      });
+    });
+  }
+}
+
 test('NoteUpdateWorkflow uses configured fields for word-card enrichment with Lapis and Kiku enabled', async () => {
   const harness = createWorkflowHarness();
   harness.deps.getConfig = () => ({


### PR DESCRIPTION
## Summary

Clarify that the configured Anki audio field receives sentence clips, including media timing review, and must remain separate from Yomitan's word pronunciation field. Add regression coverage for the configured audio field across timing actions.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal
- [x] Documentation
- [ ] Other

## How was this tested?

Added focused tests covering `SentenceAudio` and `ContextAudio` with both `confirm` and `use-original` timing actions. Checks were not run while preparing this request.

## Checklist

- [x] Reconciled current-outcome changelog fragment(s), or this PR is labeled `skip-changelog` (see [`changes/README.md`](../changes/README.md))
- [x] Docs updated in the same PR if behavior, defaults, flags, shortcuts, ports, or APIs changed
- [ ] Relevant checks pass locally (typecheck, tests, build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for sentence and context audio updates across confirmed and original timing-review actions.
  * Verified generated audio is placed in the selected field without changing the expression audio field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->